### PR TITLE
Clarify yq prerequisite

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,20 @@ Local CI parses your workflow file, runs selected jobs in containers with pre-bu
 |-----------|----------------------|
 | Python 3.10+ | CLI runtime        |
 | Docker    | Container execution  |
-| [yq](https://github.com/mikefarah/yq) | YAML parsing |
+| **[mikefarah/yq](https://github.com/mikefarah/yq) v4+** | YAML parsing -- **not** pip `yq` (PyPI) or [kislyuk/yq](https://github.com/kislyuk/yq) |
 | [act](https://github.com/nektos/act)  | Run GitHub Actions locally |
+
+### yq (mikefarah/yq v4 or newer)
+
+Several incompatible tools share the name `yq`. Local CI requires **[mikefarah/yq](https://github.com/mikefarah/yq)** **v4+** (`yq --version` output should reference `mikefarah` / `github.com/mikefarah` or report `version v4`). The wrong install fails at runtime with unclear errors. If no suitable binary is on `PATH`, the CLI uses a PyYAML fallback with limited expression support and emits a warning.
+
+| OS | Example install |
+|----|-----------------|
+| **Windows** | `winget install MikeFarah.yq` or `choco install yq` — or a binary from [Releases](https://github.com/mikefarah/yq/releases) |
+| **macOS** | `brew install yq` |
+| **Linux** | `sudo snap install yq` **or** install the static binary from [Releases](https://github.com/mikefarah/yq/releases) (verify with `yq --version` before relying on a distro package) |
+
+More options: [mikefarah/yq — Install](https://github.com/mikefarah/yq#install).
 
 ## Installation
 

--- a/cli/Usage Guide.md
+++ b/cli/Usage Guide.md
@@ -53,7 +53,7 @@ Key features:
 |------|---------|---------|
 | Python 3.10+ | Runtime | [python.org](https://www.python.org/downloads/) |
 | Docker | Container execution | [Docker Desktop](https://www.docker.com/products/docker-desktop/) |
-| yq | YAML parsing | `choco install yq` / `brew install yq` / `apt install yq` |
+| **mikefarah/yq v4+** | YAML parsing (not pip `yq` / kislyuk) | **Windows:** `winget install MikeFarah.yq` or `choco install yq` — **macOS:** `brew install yq` — **Linux:** `sudo snap install yq` or [release binary](https://github.com/mikefarah/yq/releases) — see [yq#install](https://github.com/mikefarah/yq#install) |
 | act | Local GitHub Actions | `choco install act-cli` / `brew install act` / `curl -s https://raw.githubusercontent.com/nektos/act/master/install.sh \| sudo bash` |
 
 ### Install for usage

--- a/cli/localci/utils/yq.py
+++ b/cli/localci/utils/yq.py
@@ -17,6 +17,7 @@ import re
 import shutil
 import subprocess
 import sys
+import warnings
 from pathlib import Path
 from typing import Any, Optional
 
@@ -44,12 +45,18 @@ class YqNotFoundError(Exception):
 
     def __init__(self) -> None:
         super().__init__(
-            "yq is not installed.\n"
-            "Install with:\n"
-            "  Windows:  choco install yq\n"
-            "  Linux:    sudo snap install yq  OR  sudo apt-get install yq\n"
+            "mikefarah/yq is not installed.\n"
+            "Install v4+ (not pip's `yq` / kislyuk/yq): "
+            "https://github.com/mikefarah/yq#install\n"
+            "Examples:\n"
+            "  Windows:  winget install MikeFarah.yq  OR  choco install yq\n"
+            "  Linux:    sudo snap install yq  OR  install from GitHub releases\n"
             "  macOS:    brew install yq"
         )
+
+
+class YqFallbackWarning(UserWarning):
+    """PyYAML fallback is active because mikefarah/yq v4+ is missing or wrong flavour."""
 
 
 # =====================================================================
@@ -64,7 +71,8 @@ class YqWrapper:
     uses the ``yq`` binary for **all** queries when it is available.
     When ``yq`` is absent a PyYAML-based fallback handles the simple
     dot-path expressions used by the built-in high-level helpers, and
-    logs a warning so the user knows to install ``yq``.
+    emits :exc:`YqFallbackWarning` plus a log line so the user knows to
+    install ``mikefarah/yq`` v4+.
     """
 
     def __init__(self) -> None:
@@ -84,24 +92,37 @@ class YqWrapper:
                     "sudo snap install yq" if self._is_linux
                     else "https://github.com/mikefarah/yq/releases"
                 )
-                logger.warning(
-                    "yq at %s is not mikefarah/yq (detected: %s) -- "
-                    "using PyYAML fallback (limited expression support). "
-                    "Install mikefarah/yq for best results: %s",
-                    raw_path, flavour, install_hint,
+                detail = (
+                    f"The `yq` on PATH at {raw_path!r} is not mikefarah/yq v4+ "
+                    f"(detected: {flavour}). "
+                    f"Install mikefarah/yq: {install_hint}"
                 )
+                self._warn_pyyaml_fallback(detail)
         else:
             # No yq binary found at all
             if self._is_linux:
-                logger.warning(
-                    "mikefarah/yq not available on Linux -- using PyYAML fallback. "
-                    "Install with: sudo snap install yq"
+                detail = (
+                    "No mikefarah/yq v4+ binary was found on PATH on Linux. "
+                    "Example: sudo snap install yq"
                 )
             else:
-                logger.warning(
-                    "mikefarah/yq not available -- using PyYAML fallback. "
-                    "Install yq for full expression support."
+                detail = (
+                    "No mikefarah/yq v4+ binary was found on PATH. "
+                    "See https://github.com/mikefarah/yq#install"
                 )
+            self._warn_pyyaml_fallback(detail)
+
+    def _warn_pyyaml_fallback(self, detail: str) -> None:
+        """Log and emit a visible warning when PyYAML fallback is used."""
+        msg = (
+            "Local CI is using the PyYAML YAML fallback (limited yq expression "
+            "support). "
+            f"{detail} "
+            "Required: mikefarah/yq v4 or newer — "
+            "https://github.com/mikefarah/yq#install"
+        )
+        logger.warning(msg.replace("\n", " "))
+        warnings.warn(msg, YqFallbackWarning, stacklevel=3)
 
     @staticmethod
     def _detect_yq_flavour(yq_path: str) -> str:

--- a/cli/tests/test_yq.py
+++ b/cli/tests/test_yq.py
@@ -15,6 +15,10 @@ from localci.utils.yq import YqWrapper
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 SAMPLE_CI = FIXTURES_DIR / "sample_ci.yml"
 
+# YqWrapper() triggers one-time PyYAML fallback warnings when mikefarah/yq
+# is missing on the test machine; filter that expected category for this module.
+pytestmark = pytest.mark.filterwarnings("ignore::localci.utils.yq.YqFallbackWarning")
+
 
 @pytest.fixture
 def yq():


### PR DESCRIPTION
- cli/Usage Guide.md prerequisites row updated to mikefarah v4+ with per-OS examples.
- YqNotFoundError message rewritten to call out mikefarah/yq v4+ explicitly and to exclude pip yq and kislyuk/yq.

close https://github.com/cppalliance/local-ci-test-system/issues/31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `mikefarah/yq v4+` is required for YAML parsing; other `yq` projects will not work.
  * Added version verification guidance and platform-specific installation instructions (Windows, macOS, Linux).
  * Documented PyYAML fallback behavior with limited expression support and warnings.

* **Improvements**
  * Enhanced warning visibility when incorrect `yq` binary is detected or missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->