### PR TITLE
Fix duplicated cycle detection with consistent error handling

### DIFF
--- a/cli/localci/core/queue.py
+++ b/cli/localci/core/queue.py
@@ -105,6 +105,13 @@ class DependencyResolver:
             self._reverse[dep].append(job_id)
 
     def resolve(self) -> list[str]:
+        """Return a topological order of registered jobs.
+
+        Dependencies listed in ``needs`` but never passed to :meth:`add_job`
+        are still visited with an empty edge list and included in the order.
+        Callers (e.g. ``Workflow.dependency_order``) must register a complete
+        graph.
+        """
         visited: set[str] = set()
         temp_visited: set[str] = set()
         order: list[str] = []

--- a/cli/localci/core/queue.py
+++ b/cli/localci/core/queue.py
@@ -109,20 +109,24 @@ class DependencyResolver:
         temp_visited: set[str] = set()
         order: list[str] = []
 
-        def visit(jid: str) -> None:
+        def visit(jid: str, path: list[str]) -> None:
             if jid in temp_visited:
-                raise CyclicDependencyError(jid)
+                idx = path.index(jid)
+                cycle = path[idx:] + [jid]
+                raise CyclicDependencyError(cycle)
             if jid in visited:
                 return
             temp_visited.add(jid)
+            path.append(jid)
             for dep in self._graph.get(jid, []):
-                visit(dep)
+                visit(dep, path)
+            path.pop()
             temp_visited.discard(jid)
             visited.add(jid)
             order.append(jid)
 
         for jid in self._graph:
-            visit(jid)
+            visit(jid, [])
         return order
 
     def get_dependencies(self, job_id: str) -> list[str]:

--- a/cli/localci/core/workflow.py
+++ b/cli/localci/core/workflow.py
@@ -302,30 +302,17 @@ class Workflow:
 
     def dependency_order(self) -> list[str]:
         """Topological sort of jobs by dependencies."""
-        visited: set[str] = set()
-        in_progress: set[str] = set()
-        order: list[str] = []
+        from localci.core.queue import DependencyResolver
 
-        def visit(job_id: str) -> None:
-            if job_id in visited:
-                return
-            if job_id not in self.jobs:
-                logger.warning("Dependency '%s' not found in jobs", job_id)
-                return
-            if job_id in in_progress:
-                logger.warning("Circular dependency detected involving '%s'", job_id)
-                return
-            in_progress.add(job_id)
-            visited.add(job_id)
-            for dep in self.jobs[job_id].needs:
-                visit(dep)
-            in_progress.discard(job_id)
-            order.append(job_id)
-
-        for job_id in self.jobs:
-            visit(job_id)
-
-        return order
+        resolver = DependencyResolver()
+        job_ids = set(self.jobs)
+        for job_id, job in self.jobs.items():
+            needs = [d for d in job.needs if d in job_ids]
+            for dep in job.needs:
+                if dep not in job_ids:
+                    logger.warning("Dependency '%s' not found in jobs", dep)
+            resolver.add_job(job_id, needs)
+        return resolver.resolve()
 
 
 # =====================================================================

--- a/cli/localci/core/workflow.py
+++ b/cli/localci/core/workflow.py
@@ -15,6 +15,7 @@ from enum import Enum
 from pathlib import Path
 from typing import Any, Optional
 
+from localci.core.queue import DependencyResolver
 from localci.errors import (
     LocalCIError,
     MissingFieldError,
@@ -302,8 +303,6 @@ class Workflow:
 
     def dependency_order(self) -> list[str]:
         """Topological sort of jobs by dependencies."""
-        from localci.core.queue import DependencyResolver
-
         resolver = DependencyResolver()
         job_ids = set(self.jobs)
         for job_id, job in self.jobs.items():

--- a/cli/localci/errors.py
+++ b/cli/localci/errors.py
@@ -188,9 +188,23 @@ class UnsupportedMatrixError(WorkflowError):
 
 
 class CyclicDependencyError(WorkflowError):
-    """Circular dependency detected in job graph."""
+    """Circular dependency detected in job graph.
+
+    Attributes
+    ----------
+    cycle:
+        Ordered job IDs forming the loop; first and last elements are equal
+        (e.g. ``["a", "b", "a"]``).
+    job_id:
+        First job in the cycle, kept for backward compatibility (``cycle[0]``).
+    """
 
     def __init__(self, cycle: list[str]) -> None:
+        if not isinstance(cycle, list):
+            raise TypeError(
+                f"cycle must be a list[str], got {type(cycle).__name__!r}; "
+                "pass an ordered path such as ['a', 'b', 'a'], not a single job_id string"
+            )
         self.cycle = list(cycle)
         self.job_id = self.cycle[0] if self.cycle else ""
         path = " -> ".join(self.cycle)

--- a/cli/localci/errors.py
+++ b/cli/localci/errors.py
@@ -190,9 +190,11 @@ class UnsupportedMatrixError(WorkflowError):
 class CyclicDependencyError(WorkflowError):
     """Circular dependency detected in job graph."""
 
-    def __init__(self, job_id: str) -> None:
-        super().__init__(f"Cyclic dependency detected involving job: {job_id}")
-        self.job_id = job_id
+    def __init__(self, cycle: list[str]) -> None:
+        self.cycle = list(cycle)
+        self.job_id = self.cycle[0] if self.cycle else ""
+        path = " -> ".join(self.cycle)
+        super().__init__(f"Cyclic dependency detected: {path}")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_errors.py
+++ b/cli/tests/test_errors.py
@@ -168,6 +168,14 @@ class TestErrorAttributes:
         assert "unexpected key" in str(exc)
         assert str(p) in str(exc)
 
+    def test_cyclic_dependency_error_attributes(self):
+        cycle = ["a", "b", "a"]
+        exc = CyclicDependencyError(cycle)
+        assert exc.cycle == cycle
+        assert exc.job_id == "a"
+        assert "a -> b -> a" in str(exc)
+        assert isinstance(exc, WorkflowError)
+
 
 # ---------------------------------------------------------------------------
 # Backward-compatibility: caught by built-in types

--- a/cli/tests/test_errors.py
+++ b/cli/tests/test_errors.py
@@ -176,6 +176,10 @@ class TestErrorAttributes:
         assert "a -> b -> a" in str(exc)
         assert isinstance(exc, WorkflowError)
 
+    def test_cyclic_dependency_error_rejects_string(self):
+        with pytest.raises(TypeError, match="cycle must be a list"):
+            CyclicDependencyError("ab")
+
 
 # ---------------------------------------------------------------------------
 # Backward-compatibility: caught by built-in types

--- a/cli/tests/test_queue.py
+++ b/cli/tests/test_queue.py
@@ -121,12 +121,10 @@ class TestDependencyResolver:
         with pytest.raises(CyclicDependencyError) as exc_info:
             resolver.resolve()
         exc = exc_info.value
-        assert exc.cycle
-        assert "a" in exc.cycle
-        assert "b" in exc.cycle
-        assert "a" in str(exc)
-        assert "b" in str(exc)
-        assert " -> " in str(exc)
+        assert exc.cycle == ["a", "b", "a"]
+        assert exc.cycle[0] == exc.cycle[-1]
+        assert exc.job_id == "a"
+        assert "a -> b -> a" in str(exc)
 
     def test_all_dependencies_met(self):
         resolver = DependencyResolver()

--- a/cli/tests/test_queue.py
+++ b/cli/tests/test_queue.py
@@ -118,8 +118,15 @@ class TestDependencyResolver:
         resolver = DependencyResolver()
         resolver.add_job("a", ["b"])
         resolver.add_job("b", ["a"])
-        with pytest.raises(CyclicDependencyError):
+        with pytest.raises(CyclicDependencyError) as exc_info:
             resolver.resolve()
+        exc = exc_info.value
+        assert exc.cycle
+        assert "a" in exc.cycle
+        assert "b" in exc.cycle
+        assert "a" in str(exc)
+        assert "b" in str(exc)
+        assert " -> " in str(exc)
 
     def test_all_dependencies_met(self):
         resolver = DependencyResolver()

--- a/cli/tests/test_workflow.py
+++ b/cli/tests/test_workflow.py
@@ -374,11 +374,10 @@ class TestDependencyOrder:
         with pytest.raises(CyclicDependencyError) as exc_info:
             workflow.dependency_order()
         exc = exc_info.value
-        assert exc.cycle
-        assert "a" in exc.cycle
-        assert "b" in exc.cycle
-        assert "a" in str(exc)
-        assert "b" in str(exc)
+        assert exc.cycle == ["a", "b", "a"]
+        assert exc.cycle[0] == exc.cycle[-1]
+        assert exc.job_id == "a"
+        assert "a -> b -> a" in str(exc)
 
 
 # =====================================================================

--- a/cli/tests/test_workflow.py
+++ b/cli/tests/test_workflow.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import pytest
 
+from localci.errors import CyclicDependencyError
 from localci.core.workflow import (
     BuildSystem,
     BuildVariant,
@@ -349,6 +350,35 @@ class TestDependencyOrder:
     def test_changelog_needs_build(self, sample_workflow):
         changelog = sample_workflow.jobs["changelog"]
         assert "build" in changelog.needs
+
+    def test_cyclic_dependency_raises(self, tmp_path):
+        workflow = Workflow(
+            name="cyclic",
+            file_path=tmp_path / "cyclic.yml",
+            events=["push"],
+            jobs={
+                "a": Job(
+                    id="a",
+                    name="A",
+                    runs_on="ubuntu-latest",
+                    needs=["b"],
+                ),
+                "b": Job(
+                    id="b",
+                    name="B",
+                    runs_on="ubuntu-latest",
+                    needs=["a"],
+                ),
+            },
+        )
+        with pytest.raises(CyclicDependencyError) as exc_info:
+            workflow.dependency_order()
+        exc = exc_info.value
+        assert exc.cycle
+        assert "a" in exc.cycle
+        assert "b" in exc.cycle
+        assert "a" in str(exc)
+        assert "b" in str(exc)
 
 
 # =====================================================================


### PR DESCRIPTION
## Summary

- Unify job dependency cycle detection into a single canonical path: `DependencyResolver.resolve()` in `cli/localci/core/queue.py`.
- Make `Workflow.dependency_order()` delegate to `DependencyResolver` instead of running its own DFS that logged a warning and returned a partial order on cycles.
- Extend `CyclicDependencyError` with a `cycle: list[str]` attribute and a message that shows the full cycle path (e.g. `a -> b -> a`) for easier debugging.

## What changed

| Area | Change |
|------|--------|
| `cli/localci/errors.py` | `CyclicDependencyError` now accepts `cycle: list[str]`; message uses `" -> ".join(cycle)`; `job_id` retained as `cycle[0]` for compatibility |
| `cli/localci/core/queue.py` | `DependencyResolver.resolve()` builds the cycle path on detection and raises `CyclicDependencyError(cycle)` |
| `cli/localci/core/workflow.py` | `dependency_order()` populates a `DependencyResolver`, filters unknown `needs` (with existing warning), and calls `resolve()` |
| Tests | Strengthened queue cyclic test; added workflow and error-attribute tests |

## Behavior change

Cyclic job dependencies now **always raise** `CyclicDependencyError` with a cycle path, whether detected via `DependencyResolver.resolve()` or `Workflow.dependency_order()`. Previously, `dependency_order()` could silently return a partial topological order.

## Test plan

- [x] `pytest tests/test_queue.py::TestDependencyResolver::test_cyclic_dependency` — cycle detected, `cycle` populated, path in message
- [x] `pytest tests/test_workflow.py::TestDependencyOrder::test_cyclic_dependency_raises` — workflow path delegates and raises same error type
- [x] `pytest tests/test_errors.py::TestErrorAttributes::test_cyclic_dependency_error_attributes` — `cycle`, message, `WorkflowError` hierarchy
- [x] Existing happy-path dependency order tests pass (`test_workflow.py`, `test_full_workflow.py`)
- [x] Full suite: `cd cli && pytest --cov=localci --cov-report=term-missing` (490 passed)

## Out of scope

- Enqueue-time cycle validation in `PriorityJobQueue` (still uses `all_dependencies_met()` only; not required by w4_issue_03)

## Related issue

close https://github.com/cppalliance/local-ci-test-system/issues/40

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cycle detection and reporting: circular dependency errors now include the full ordered cycle (e.g., "a -> b -> a"), expose the cycle sequence, and validate the reported cycle format.
  * Dependency ordering now uses a shared resolver and emits warnings for dependencies referenced but not registered.

* **Tests**
  * Added and strengthened tests to verify cycle reporting, exception contents, validation behavior, and that dependency ordering raises the appropriate error.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cppalliance/local-ci-test-system/pull/42?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->