### PR TITLE
test: add unit tests for _write_patched_workflow patch types (closes #50)

### DIFF
--- a/cli/localci/cli/run/patcher.py
+++ b/cli/localci/cli/run/patcher.py
@@ -203,8 +203,8 @@ def _write_patched_workflow(
                 step_start -= 1
             # Idempotency: skip if already patched
             already_patched = any(
-                "LOCALCI_B2_SOURCE_DIR" in lines[j] and "bootstrap" in lines[j]
-                for j in range(max(0, step_start - 10), step_start)
+                "Skip b2 bootstrap (b2 binary cached)" in lines[j]
+                for j in range(max(0, step_start - 15), step_start)
             )
             if not already_patched:
                 new_step = [

--- a/cli/localci/cli/run/patcher.py
+++ b/cli/localci/cli/run/patcher.py
@@ -203,7 +203,7 @@ def _write_patched_workflow(
                 step_start -= 1
             # Idempotency: skip if already patched
             already_patched = any(
-                "Skip b2 bootstrap (b2 binary cached)" in lines[j]
+                "Skip b2 bootstrap" in lines[j]
                 for j in range(max(0, step_start - 15), step_start)
             )
             if not already_patched:

--- a/cli/tests/fixtures/patcher/already_patched.yml
+++ b/cli/tests/fixtures/patcher/already_patched.yml
@@ -1,0 +1,25 @@
+name: Already Patched
+on:
+  push:
+jobs:
+  build:
+    steps:
+      - name: Restore capy source file timestamps
+        run: |
+          if [ -n "${LOCALCI_B2_SOURCE_DIR:-}" ] && [ -f "${LOCALCI_B2_SOURCE_DIR}/.capy-file-stats" ]; then
+            echo restore
+          fi
+      - name: Patch Boost
+        run: |
+          if [ -n "${LOCALCI_B2_SOURCE_DIR:-}" ] && [ -f "${LOCALCI_B2_SOURCE_DIR}/Jamroot" ]; then
+            ln -sfn "${LOCALCI_B2_SOURCE_DIR}" boost-root
+          else
+            cp -rL boost-source boost-root
+          fi
+      - name: Skip b2 bootstrap (b2 binary cached)
+        run: |
+          if [ -n "${LOCALCI_B2_SOURCE_DIR:-}" ] && [ -f "${LOCALCI_B2_SOURCE_DIR}/b2" ]; then
+            printf '#!/bin/sh\necho cached\n' > boost-root/bootstrap.sh
+          fi
+      - name: B2 Build
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.9.0

--- a/cli/tests/fixtures/patcher/b2_workflow.yml
+++ b/cli/tests/fixtures/patcher/b2_workflow.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: B2 Build
         uses: alandefreitas/cpp-actions/b2-workflow@v1.9.0

--- a/cli/tests/fixtures/patcher/b2_workflow.yml
+++ b/cli/tests/fixtures/patcher/b2_workflow.yml
@@ -1,0 +1,8 @@
+name: B2 Bootstrap Patch
+on:
+  push:
+jobs:
+  build:
+    steps:
+      - name: B2 Build
+        uses: alandefreitas/cpp-actions/b2-workflow@v1.9.0

--- a/cli/tests/fixtures/patcher/boost_cache.yml
+++ b/cli/tests/fixtures/patcher/boost_cache.yml
@@ -1,0 +1,9 @@
+name: Boost Cache Patch
+on:
+  push:
+jobs:
+  build:
+    steps:
+      - name: Patch Boost
+        run: |
+          cp -rL boost-source boost-root

--- a/cli/tests/fixtures/patcher/boost_cache.yml
+++ b/cli/tests/fixtures/patcher/boost_cache.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Patch Boost
         run: |

--- a/cli/tests/fixtures/patcher/capy_copy.yml
+++ b/cli/tests/fixtures/patcher/capy_copy.yml
@@ -1,0 +1,9 @@
+name: Capy Copy Patch
+on:
+  push:
+jobs:
+  build:
+    steps:
+      - name: Patch Boost
+        run: |
+          cp -r "$workspace_root"/capy-root "libs/$module"

--- a/cli/tests/fixtures/patcher/capy_copy.yml
+++ b/cli/tests/fixtures/patcher/capy_copy.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Patch Boost
         run: |

--- a/cli/tests/fixtures/patcher/codecov.yml
+++ b/cli/tests/fixtures/patcher/codecov.yml
@@ -1,0 +1,10 @@
+name: Codecov Patch
+on:
+  push:
+jobs:
+  build:
+    steps:
+      - name: Upload coverage
+        run: |
+          lcov --directory . --capture --output-file coverage.info
+          bash <(curl -s https://codecov.io/bash) -f coverage.info

--- a/cli/tests/fixtures/patcher/codecov.yml
+++ b/cli/tests/fixtures/patcher/codecov.yml
@@ -3,6 +3,7 @@ on:
   push:
 jobs:
   build:
+    runs-on: ubuntu-latest
     steps:
       - name: Upload coverage
         run: |

--- a/cli/tests/fixtures/patcher/container_image.yml
+++ b/cli/tests/fixtures/patcher/container_image.yml
@@ -12,5 +12,6 @@ jobs:
           - name: "GCC 12: C++20"
             container: "ubuntu:22.04"
             runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
     steps:
       - run: echo build

--- a/cli/tests/fixtures/patcher/container_image.yml
+++ b/cli/tests/fixtures/patcher/container_image.yml
@@ -1,0 +1,16 @@
+name: Container Image Patch
+on:
+  push:
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: "GCC 15: C++20"
+            container: "ubuntu:25.04"
+            runs-on: ubuntu-latest
+          - name: "GCC 12: C++20"
+            container: "ubuntu:22.04"
+            runs-on: ubuntu-latest
+    steps:
+      - run: echo build

--- a/cli/tests/fixtures/patcher/container_mount.yml
+++ b/cli/tests/fixtures/patcher/container_mount.yml
@@ -1,0 +1,10 @@
+name: Container Mount Patch
+on:
+  push:
+jobs:
+  build:
+    container:
+      image: ubuntu:24.04
+      options: --privileged
+    steps:
+      - run: echo build

--- a/cli/tests/fixtures/patcher/container_mount_no_options.yml
+++ b/cli/tests/fixtures/patcher/container_mount_no_options.yml
@@ -1,0 +1,9 @@
+name: Container Mount No Options
+on:
+  push:
+jobs:
+  build:
+    container:
+      image: ubuntu:24.04
+    steps:
+      - run: echo build

--- a/cli/tests/fixtures/patcher/empty_matrix.yml
+++ b/cli/tests/fixtures/patcher/empty_matrix.yml
@@ -1,0 +1,10 @@
+name: Empty Matrix
+on:
+  push:
+jobs:
+  build:
+    strategy:
+      matrix:
+        include: []
+    steps:
+      - run: echo no-matrix

--- a/cli/tests/fixtures/patcher/no_runs_on.yml
+++ b/cli/tests/fixtures/patcher/no_runs_on.yml
@@ -1,0 +1,11 @@
+name: No Runs On
+on:
+  push:
+env:
+  KEEP_ME: unchanged
+jobs:
+  build:
+    steps:
+      - name: Patch Boost
+        run: |
+          cp -rL boost-source boost-root

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -96,7 +96,9 @@ class TestList:
         )
         assert result.exit_code == 0
 
-    def test_no_workflow_errors(self):
+    def test_no_workflow_errors(self, tmp_path, monkeypatch):
+        """Without --workflow, list fails when no workflow file is reachable."""
+        monkeypatch.chdir(tmp_path)
         result = runner.invoke(cli, ["list"])
         assert result.exit_code != 0
 
@@ -107,11 +109,20 @@ class TestList:
             f"version: 1\nworkflow: {SAMPLE_CI}\njobs:\n  include:\n    - GCC 15\n"
         )
         result = runner.invoke(
-            cli, ["-c", str(config_file), "list", "--enabled", "--format", "simple"]
+            cli,
+            [
+                "-c",
+                str(config_file),
+                "list",
+                "--enabled",
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 0
-        # Should only show entries whose name matches "GCC 15"
-        assert "GCC 15" in result.output
+        entries = json.loads(result.output)
+        assert entries
+        assert all("GCC 15" in e["name"] for e in entries)
 
     def test_list_disabled_with_config(self, tmp_path):
         """--disabled filters by config.jobs.exclude when present."""
@@ -120,11 +131,20 @@ class TestList:
             f"version: 1\nworkflow: {SAMPLE_CI}\njobs:\n  exclude:\n    - GCC 15\n"
         )
         result = runner.invoke(
-            cli, ["-c", str(config_file), "list", "--disabled", "--format", "simple"]
+            cli,
+            [
+                "-c",
+                str(config_file),
+                "list",
+                "--disabled",
+                "--format",
+                "json",
+            ],
         )
         assert result.exit_code == 0
-        # Disabled shows only entries in exclude (names matching "GCC 15")
-        assert "GCC 15" in result.output
+        entries = json.loads(result.output)
+        assert entries
+        assert all("GCC 15" in e["name"] for e in entries)
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -115,13 +115,15 @@ class TestContainerImagePatch:
 
 class TestContainerMountPatch:
     @pytest.mark.parametrize(
-        ("fixture_name", "expect_inserted"),
+        ("fixture_name", "has_existing_options"),
         [
-            ("container_mount.yml", False),
-            ("container_mount_no_options.yml", True),
+            ("container_mount.yml", True),
+            ("container_mount_no_options.yml", False),
         ],
     )
-    def test_positive_injects_mount_options(self, patcher_paths, fixture_name, expect_inserted):
+    def test_positive_injects_mount_options(
+        self, patcher_paths, fixture_name, has_existing_options
+    ):
         mounts = "-v /host/boost:/tmp/localci-cache/boost"
         workflow = FIXTURES_DIR / fixture_name
         patched = patcher_paths(
@@ -132,7 +134,8 @@ class TestContainerMountPatch:
         content = _assert_valid_yaml(patched)
 
         assert mounts in content
-        if not expect_inserted:
+        assert "options:" in content
+        if has_existing_options:
             assert "--privileged" in content
 
     def test_negative_skips_without_job_id(self, patcher_paths):
@@ -217,7 +220,7 @@ class TestCapyCopyPatch:
         assert "sha256sum" in content
         assert 'cp -r "$workspace_root"' not in content
 
-    def test_negative_leaves_workflow_without_capy_copy_unchanged(self, patcher_paths):
+    def test_negative_no_cp_rp_injected_when_capy_copy_line_absent(self, patcher_paths):
         workflow = FIXTURES_DIR / "boost_cache.yml"
         patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
@@ -263,12 +266,11 @@ class TestCodecovPatch:
 
     def test_negative_leaves_workflow_without_codecov_unchanged(self, patcher_paths):
         workflow = FIXTURES_DIR / "boost_cache.yml"
-        original = workflow.read_text(encoding="utf-8")
         patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert "codecov.io" not in content
         assert "ACT" not in content
-        assert original.splitlines()[0] in content
+        assert "LOCALCI_B2_SOURCE_DIR" in content
 
 
 # ---------------------------------------------------------------------------
@@ -303,7 +305,8 @@ class TestPatcherEdgeCases:
         b2_workflow = FIXTURES_DIR / "b2_workflow.yml"
         first_b2 = patcher_paths(b2_workflow)
         second_b2 = patcher_paths(first_b2, _make_entry())
-        _assert_valid_yaml(second_b2)
+        b2_content = _assert_valid_yaml(second_b2)
+        assert b2_content.count("Skip b2 bootstrap (b2 binary cached)") == 1
 
 
 @pytest.mark.parametrize(
@@ -311,10 +314,17 @@ class TestPatcherEdgeCases:
     [
         ("container_image.yml", {"image_tag": "localci/test:latest"}),
         ("container_mount.yml", {"job_id": "build", "container_mount_options": "-v /cache:/cache"}),
+        (
+            "container_mount_no_options.yml",
+            {"job_id": "build", "container_mount_options": "-v /cache:/cache"},
+        ),
         ("boost_cache.yml", {}),
         ("capy_copy.yml", {}),
         ("b2_workflow.yml", {}),
         ("codecov.yml", {}),
+        ("already_patched.yml", {}),
+        ("empty_matrix.yml", {}),
+        ("no_runs_on.yml", {}),
     ],
 )
 def test_all_fixtures_produce_valid_yaml(patcher_paths, fixture_name, patch_kwargs):

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -1,0 +1,324 @@
+"""Unit tests for _write_patched_workflow patch types (issue #50).
+
+Each patch type has positive and negative cases using minimal YAML fixtures.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from localci.cli.run import _write_patched_workflow
+from localci.core.workflow import (
+    BuildSystem,
+    BuildVariant,
+    CompilerFamily,
+    CompilerInfo,
+    ContainerInfo,
+    MatrixEntry,
+    PackageRequirements,
+    Platform,
+)
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "patcher"
+
+
+def _make_entry(name: str = "GCC 15: C++20") -> MatrixEntry:
+    return MatrixEntry(
+        index=0,
+        name=name,
+        platform=Platform.LINUX,
+        compiler=CompilerInfo(
+            family=CompilerFamily.GCC,
+            version="15",
+            cc="gcc-15",
+            cxx="g++-15",
+        ),
+        container=ContainerInfo(image="ubuntu:25.04"),
+        variant=BuildVariant(),
+        packages=PackageRequirements(),
+        runs_on="ubuntu-latest",
+        build_system=BuildSystem.B2,
+        raw={},
+    )
+
+
+@pytest.fixture
+def patcher_paths():
+    """Track patched temp files and unlink on teardown."""
+    paths: list[Path] = []
+
+    def _patch(workflow_path: Path, entry: MatrixEntry | None = None, **kwargs) -> Path:
+        patched = _write_patched_workflow(
+            workflow_path,
+            entry or _make_entry(),
+            **kwargs,
+        )
+        paths.append(patched)
+        return patched
+
+    yield _patch
+    for path in paths:
+        path.unlink(missing_ok=True)
+
+
+def _assert_valid_yaml(path: Path) -> str:
+    content = path.read_text(encoding="utf-8")
+    yaml.safe_load(content)
+    return content
+
+
+# ---------------------------------------------------------------------------
+# container image substitution (matrix entry targeting)
+# ---------------------------------------------------------------------------
+
+
+class TestContainerImagePatch:
+    def test_positive_replaces_container_for_named_matrix_entry(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_image.yml"
+        original = workflow.read_text(encoding="utf-8")
+        patched = patcher_paths(
+            workflow,
+            _make_entry("GCC 15: C++20"),
+            image_tag="localci/gcc-15:custom",
+        )
+        content = _assert_valid_yaml(patched)
+
+        assert 'container: "localci/gcc-15:custom"' in content
+        assert 'container: "ubuntu:22.04"' in content
+        assert "runs-on: ubuntu-latest" in content
+        assert original.count("runs-on: ubuntu-latest") == content.count("runs-on: ubuntu-latest")
+
+    def test_negative_raises_when_matrix_entry_name_missing(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_image.yml"
+        with pytest.raises(ValueError, match="Matrix entry name 'No Such Entry' not found"):
+            patcher_paths(
+                workflow,
+                _make_entry("No Such Entry"),
+                image_tag="localci/missing:latest",
+            )
+
+    def test_negative_skips_when_image_tag_not_provided(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_image.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert 'container: "ubuntu:25.04"' in content
+        assert "localci/" not in content
+
+
+# ---------------------------------------------------------------------------
+# container mount options (cache injection)
+# ---------------------------------------------------------------------------
+
+
+class TestContainerMountPatch:
+    @pytest.mark.parametrize(
+        ("fixture_name", "expect_inserted"),
+        [
+            ("container_mount.yml", False),
+            ("container_mount_no_options.yml", True),
+        ],
+    )
+    def test_positive_injects_mount_options(self, patcher_paths, fixture_name, expect_inserted):
+        mounts = "-v /host/boost:/tmp/localci-cache/boost"
+        workflow = FIXTURES_DIR / fixture_name
+        patched = patcher_paths(
+            workflow,
+            job_id="build",
+            container_mount_options=mounts,
+        )
+        content = _assert_valid_yaml(patched)
+
+        assert mounts in content
+        if not expect_inserted:
+            assert "--privileged" in content
+
+    def test_negative_skips_without_job_id(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_mount.yml"
+        original = workflow.read_text(encoding="utf-8")
+        patched = patcher_paths(
+            workflow,
+            container_mount_options="-v /host/boost:/cache",
+        )
+        content = _assert_valid_yaml(patched)
+        assert content == original.replace("\r\n", "\n")
+
+    def test_negative_skips_without_mount_options(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_mount.yml"
+        original = workflow.read_text(encoding="utf-8")
+        patched = patcher_paths(workflow, job_id="build")
+        content = _assert_valid_yaml(patched)
+        assert content == original.replace("\r\n", "\n")
+
+
+# ---------------------------------------------------------------------------
+# boost-source cache (cp -rL replacement)
+# ---------------------------------------------------------------------------
+
+
+class TestBoostCachePatch:
+    def test_positive_replaces_cp_with_cache_logic(self, patcher_paths):
+        workflow = FIXTURES_DIR / "boost_cache.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+
+        assert "LOCALCI_B2_SOURCE_DIR" in content
+        assert "Jamroot" in content
+        assert "ln -sfn" in content
+        assert "cp -a boost-root/." in content
+
+    def test_negative_leaves_workflow_unchanged_without_boost_copy_line(self, patcher_paths):
+        workflow = FIXTURES_DIR / "container_image.yml"
+        original = workflow.read_text(encoding="utf-8")
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert "LOCALCI_B2_SOURCE_DIR" not in content
+        assert "cp -rL boost-source boost-root" not in content
+        assert content == original.replace("\r\n", "\n")
+
+
+# ---------------------------------------------------------------------------
+# capy timestamp restore (injected before Patch Boost)
+# ---------------------------------------------------------------------------
+
+
+class TestCapyTimestampsPatch:
+    def test_positive_injects_restore_step_before_patch_boost(self, patcher_paths):
+        workflow = FIXTURES_DIR / "boost_cache.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+
+        assert "Restore capy source file timestamps" in content
+        assert ".capy-file-stats" in content
+        assert content.index("Restore capy source file timestamps") < content.index("Patch Boost")
+
+    def test_negative_skips_duplicate_on_already_patched_workflow(self, patcher_paths):
+        workflow = FIXTURES_DIR / "already_patched.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert content.count("Restore capy source file timestamps") == 1
+
+
+# ---------------------------------------------------------------------------
+# capy copy + stats (cp -r -> cp -rp)
+# ---------------------------------------------------------------------------
+
+
+class TestCapyCopyPatch:
+    def test_positive_replaces_cp_r_with_cp_rp_and_stats(self, patcher_paths):
+        workflow = FIXTURES_DIR / "capy_copy.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+
+        assert 'cp -rp "$workspace_root"/capy-root "libs/$module"' in content
+        assert ".capy-file-stats" in content
+        assert "sha256sum" in content
+        assert 'cp -r "$workspace_root"' not in content
+
+    def test_negative_leaves_workflow_without_capy_copy_unchanged(self, patcher_paths):
+        workflow = FIXTURES_DIR / "boost_cache.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert 'cp -rp "$workspace_root"' not in content
+
+
+# ---------------------------------------------------------------------------
+# b2 bootstrap skip
+# ---------------------------------------------------------------------------
+
+
+class TestB2BootstrapPatch:
+    def test_positive_injects_skip_step_before_b2_workflow(self, patcher_paths):
+        workflow = FIXTURES_DIR / "b2_workflow.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+
+        assert "Skip b2 bootstrap (b2 binary cached)" in content
+        assert "bootstrap.sh" in content
+        assert content.index("Skip b2 bootstrap") < content.index("b2-workflow")
+
+    def test_negative_skips_when_b2_workflow_step_absent(self, patcher_paths):
+        workflow = FIXTURES_DIR / "boost_cache.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert "Skip b2 bootstrap (b2 binary cached)" not in content
+
+
+# ---------------------------------------------------------------------------
+# codecov skip under act
+# ---------------------------------------------------------------------------
+
+
+class TestCodecovPatch:
+    def test_positive_wraps_upload_with_act_guard(self, patcher_paths):
+        workflow = FIXTURES_DIR / "codecov.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+
+        assert 'if [ -z "${ACT:-}" ] || [ "$ACT" != "true" ]; then' in content
+        assert "Skipping Codecov upload (running under act)" in content
+        assert "https://codecov.io/bash" in content
+
+    def test_negative_leaves_workflow_without_codecov_unchanged(self, patcher_paths):
+        workflow = FIXTURES_DIR / "boost_cache.yml"
+        original = workflow.read_text(encoding="utf-8")
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert "codecov.io" not in content
+        assert "ACT" not in content
+        assert original.splitlines()[0] in content
+
+
+# ---------------------------------------------------------------------------
+# edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestPatcherEdgeCases:
+    def test_empty_matrix_produces_valid_yaml(self, patcher_paths):
+        workflow = FIXTURES_DIR / "empty_matrix.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert "include: []" in content
+        assert "echo no-matrix" in content
+
+    def test_missing_runs_on_preserves_unrelated_sections(self, patcher_paths):
+        workflow = FIXTURES_DIR / "no_runs_on.yml"
+        patched = patcher_paths(workflow)
+        content = _assert_valid_yaml(patched)
+        assert "KEEP_ME: unchanged" in content
+        assert "runs-on" not in content
+        assert "LOCALCI_B2_SOURCE_DIR" in content
+
+    def test_repatch_preserves_idempotent_patches_and_valid_yaml(self, patcher_paths):
+        """Timestamp restore is idempotent; re-patched output stays valid YAML."""
+        workflow = FIXTURES_DIR / "already_patched.yml"
+        first = patcher_paths(workflow)
+        second = patcher_paths(first, _make_entry())
+        content = _assert_valid_yaml(second)
+        assert content.count("Restore capy source file timestamps") == 1
+
+        b2_workflow = FIXTURES_DIR / "b2_workflow.yml"
+        first_b2 = patcher_paths(b2_workflow)
+        second_b2 = patcher_paths(first_b2, _make_entry())
+        _assert_valid_yaml(second_b2)
+
+
+@pytest.mark.parametrize(
+    ("fixture_name", "patch_kwargs"),
+    [
+        ("container_image.yml", {"image_tag": "localci/test:latest"}),
+        ("container_mount.yml", {"job_id": "build", "container_mount_options": "-v /cache:/cache"}),
+        ("boost_cache.yml", {}),
+        ("capy_copy.yml", {}),
+        ("b2_workflow.yml", {}),
+        ("codecov.yml", {}),
+    ],
+)
+def test_all_fixtures_produce_valid_yaml(patcher_paths, fixture_name, patch_kwargs):
+    """Every minimal fixture remains parseable after a full patch pass."""
+    workflow = FIXTURES_DIR / fixture_name
+    patched = patcher_paths(workflow, **patch_kwargs)
+    _assert_valid_yaml(patched)


### PR DESCRIPTION
## Summary

- Add `cli/tests/test_patcher_patches.py` with isolated positive/negative tests for all seven patch types in `_write_patched_workflow` (container image, container mount, boost cache, capy timestamp restore, capy copy, b2 bootstrap skip, Codecov ACT guard).
- Add 10 minimal YAML fixtures under `cli/tests/fixtures/patcher/` so each patch is exercised without full Capy-style workflows.
- Harden `TestList` CLI tests to be cwd- and terminal-output independent (empty `tmp_path` for missing-workflow case; JSON assertions for `--enabled`/`--disabled` filters).

Closes #50. Provides regression coverage ahead of the configurable patch pipeline work in #51.

## Patch coverage

| Patch type | Positive | Negative |
|---|---|---|
| Container image (`image_tag`) | Replaces container for named matrix entry | Missing entry raises; skipped without `image_tag` |
| Container mount (`job_id` + options) | Appends/inserts `-v` mounts | Skipped without `job_id` or mount options |
| Boost cache (`cp -rL`) | Injects `LOCALCI_B2_SOURCE_DIR` logic | Unrelated workflows unchanged |
| Capy timestamp restore | Step injected before Patch Boost | No duplicate on pre-patched workflow |
| Capy copy (`cp -r` → `cp -rp`) | Stats snapshot written | Skipped when copy line absent |
| B2 bootstrap skip | Step injected before `b2-workflow` | Skipped when `b2-workflow` absent |
| Codecov ACT guard | Upload wrapped with `ACT` check | Skipped when no codecov curl line |

## Edge cases

- Empty matrix (`include: []`) → valid YAML
- Missing `runs-on` → unrelated sections preserved
- Re-patch → timestamp restore idempotent; output stays valid YAML

## Test plan

- [x] `pytest cli/tests/test_patcher_patches.py -v`
- [x] `pytest cli/tests/test_run_patcher.py -v` (existing Capy integration tests still pass)
- [x] `pytest cli/tests/test_cli.py::TestList -v`
- [x] Full unit suite: `pytest cli/tests/ --ignore=cli/tests/integration` (556 passed)
- [ ] CI green on PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added extensive unit tests and workflow fixtures to validate many patching scenarios and edge cases (container/image/mount, boost cache, capy copy/timestamps, b2 bootstrap, codecov, empty-matrix, runs-on variations), ensuring patched outputs remain valid YAML.

* **Bug Fixes**
  * Improved detection for already-injected steps to make patching idempotent and more reliable across workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->