### PR TITLE
Add mypy strict type checking to CI (closes #52)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,30 @@ on:
     branches: [main, develop]
 
 jobs:
+  typecheck:
+    name: Typecheck (mypy)
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: cli
+
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run mypy
+        run: mypy localci/
+
   test:
     name: Test (Python ${{ matrix.python-version }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.12
+      - name: Set up Python 3.10
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
         with:
-          python-version: "3.12"
+          python-version: "3.10"
 
       - name: Install dependencies
         run: pip install -e ".[dev]"
@@ -77,7 +77,7 @@ jobs:
   integration:
     name: Integration (act + Docker)
     runs-on: ubuntu-latest
-    needs: [test]
+    needs: [test, typecheck]
     timeout-minutes: 30
 
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, develop]
 
+permissions:
+  contents: read
+
 jobs:
   typecheck:
     name: Typecheck (mypy)

--- a/cli/README.md
+++ b/cli/README.md
@@ -115,6 +115,9 @@ pytest --cov=localci -m "not integration"
 
 # Integration tests (requires act + Docker; path + marker required)
 pytest tests/integration -m integration
+
+# Static type checking (strict; 85 legacy errors in 18 modules suppressed — see pyproject.toml)
+mypy localci/
 ```
 
 ## License

--- a/cli/localci/core/config.py
+++ b/cli/localci/core/config.py
@@ -371,6 +371,7 @@ def load_config(path: Path | str | None = None) -> LocalCIConfig:
         A validated configuration object.  If no config file is found,
         returns a default configuration.
     """
+    config_path: Path | None
     if path is not None:
         config_path = Path(path)
         if not config_path.is_file():

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -18,8 +18,11 @@ dependencies = [
 
 [project.optional-dependencies]
 dev = [
+    "mypy>=1.10.0",
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
+    "types-PyYAML>=6.0.0",
+    "types-psutil>=5.9.0",
 ]
 
 [project.scripts]
@@ -35,3 +38,38 @@ markers = [
     "integration: requires act and Docker; runs real subprocesses",
 ]
 norecursedirs = ["integration"]
+
+# Mypy baseline (2026-06-09): 85 errors in 18 legacy modules suppressed via
+# per-module ignore_errors overrides below. localci.core.config and
+# localci.core.models pass strict mypy with zero errors. New modules must not
+# use ignore_errors; remove overrides as legacy modules are typed.
+[tool.mypy]
+python_version = "3.10"
+strict = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+packages = ["localci"]
+
+[[tool.mypy.overrides]]
+module = [
+    "localci.cli.analyze",
+    "localci.cli.config",
+    "localci.cli.list",
+    "localci.cli.logs",
+    "localci.cli.run.click_options",
+    "localci.cli.run.patcher",
+    "localci.cli.run.run_flow",
+    "localci.cli.status",
+    "localci.core.orchestrator",
+    "localci.core.progress",
+    "localci.core.queue_builder",
+    "localci.core.registry",
+    "localci.core.results",
+    "localci.core.serialization",
+    "localci.core.workflow",
+    "localci.utils.docker",
+    "localci.utils.resources",
+    "localci.utils.yq",
+]
+ignore_errors = true

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -22,7 +22,7 @@ dev = [
     "pytest>=7.0.0",
     "pytest-cov>=4.0.0",
     "types-PyYAML>=6.0.0",
-    "types-psutil>=5.9.0",
+    "types-psutil>=5.9.0",  # for localci.utils.resources when it leaves ignore_errors
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- Add `mypy` with `--strict` configuration in `cli/pyproject.toml`, including stub packages for PyYAML and psutil.
- Add a `typecheck` job to `.github/workflows/ci.yml` that runs `mypy localci/` on every push and PR.
- Fix a type error in `localci.core.config` (`config_path: Path | None`) so `config.py` and `models.py` pass strict mypy with zero errors.
- Document a mypy baseline of **85 errors in 18 legacy modules**, suppressed via per-module `ignore_errors` overrides until those modules are typed incrementally.

Closes #52 

## Details

Addresses the eval finding in [local-ci-test-system-eval.md](https://github.com/cppalliance/team-brain/blob/main/repo-cleanup-tracker/baseline/2026-05-01/local-ci-test-system-eval.md) (Test 8, cluster `verification-typecheck`): the project had tests but no static type checking in CI.

**Modules passing strict mypy today:**
- `localci/core/config.py`
- `localci/core/models.py`

**Legacy modules with `ignore_errors` (18):** CLI (`analyze`, `config`, `list`, `logs`, `status`, `run/*`), core (`orchestrator`, `progress`, `queue_builder`, `registry`, `results`, `serialization`, `workflow`), and utils (`docker`, `resources`, `yq`).

New modules are checked under strict mode and must not be added to the override list.

## Test plan

- [x] `pip install -e ".[dev]" && mypy localci/` — passes (44 source files)
- [x] `pytest -m "not integration"` — 560 tests pass
- [ ] CI `typecheck` job passes on GitHub Actions
- [ ] CI `test` job still passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now runs static type checks as a dedicated job and requires them to pass before integration steps proceed.
  * Development dependencies updated to include type-checking tooling and stricter type-checker settings.
  * Minor internal declaration clarified to improve code clarity (no behavioral changes).
* **Documentation**
  * Added development instructions for running static type checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->