### PR TITLE
Remove GITHUB_TOKEN from act command line

### DIFF
--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -241,10 +241,6 @@ class ActCommand:
         if self.env_file:
             cmd.extend(["--env-file", str(self.env_file)])
 
-        # Secrets
-        for key, value in self.secrets.items():
-            cmd.extend(["--secret", f"{key}={value}"])
-
         # Event payload
         if self.event_file:
             cmd.extend(["-e", str(self.event_file)])
@@ -278,20 +274,8 @@ class ActCommand:
         return cmd
 
     def display(self) -> str:
-        """Human-readable command string (secrets redacted)."""
-        parts = self.build()
-        redacted: list[str] = []
-        skip_next = False
-        for part in parts:
-            if skip_next:
-                redacted.append("***")
-                skip_next = False
-            elif part == "--secret":
-                redacted.append(part)
-                skip_next = True
-            else:
-                redacted.append(part)
-        return " ".join(redacted)
+        """Human-readable command string (secrets are not included in argv)."""
+        return " ".join(self.build())
 
     def __str__(self) -> str:
         return self.display()
@@ -553,8 +537,9 @@ class JobExecutor:
     ) -> tuple[int, str, str]:
         """Execute ``act`` process with output capture and streaming.
 
-        Uses ActCommand.display() for the log header (secrets redacted) and
-        ActCommand.secrets for env, so the token is never written to disk.
+        Uses :meth:`ActCommand.display` for the log header and injects
+        :attr:`ActCommand.secrets` into the subprocess environment so secrets
+        are never passed on the command line or written to disk.
 
         Returns ``(exit_code, stdout, stderr)``.
         """
@@ -565,16 +550,15 @@ class JobExecutor:
         log_lock = threading.Lock()
 
         with open(log_file, "w", encoding="utf-8") as log_f:
-            # Write header with redacted command (no secrets on disk)
+            # Write header (argv contains no secrets)
             log_f.write("# LocalCI Job Log\n")
             log_f.write(f"# Command: {act_cmd.display()}\n")
             log_f.write(f"# Started: {datetime.now().isoformat()}\n")
             log_f.write(f"# {'=' * 60}\n\n")
 
-            # Build environment: parent env + GITHUB_TOKEN from ActCommand.secrets
+            # Inject secrets via subprocess env (never via argv)
             env = dict(os.environ)
-            if "GITHUB_TOKEN" in act_cmd.secrets:
-                env["GITHUB_TOKEN"] = act_cmd.secrets["GITHUB_TOKEN"]
+            env.update(act_cmd.secrets)
 
             process = subprocess.Popen(
                 cmd,

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -167,14 +167,15 @@ class ActCommand:
     dryrun: bool = False
     verbose: bool = False
 
-    # Environment
+    # Environment (values passed via --env-file path only; see JobExecutor)
     env: dict[str, str] = field(default_factory=dict)
     # Secrets passed to act via --secret-file (never as argv values).
     # All keys and values must be str (POSIX subprocess.Popen requirement).
     secrets: dict[str, str] = field(default_factory=dict)
     env_file: Path | None = None
-    # Temp file for --secret-file; set by JobExecutor._execute_process only.
+    # Temp files for --env-file / --secret-file; set by JobExecutor._execute_process only.
     secret_file: Path | None = None
+    _executor_owned_env_file: bool = field(default=False, repr=False)
     _executor_owned_secret_file: bool = field(default=False, repr=False)
 
     # Event
@@ -240,11 +241,7 @@ class ActCommand:
         if self.verbose:
             cmd.append("-v")
 
-        # Environment variables
-        for key, value in self.env.items():
-            cmd.extend(["--env", f"{key}={value}"])
-
-        # Env file
+        # Env file (path only on argv; values materialized by JobExecutor)
         if self.env_file:
             cmd.extend(["--env-file", str(self.env_file)])
 
@@ -548,10 +545,11 @@ class JobExecutor:
     ) -> tuple[int, str, str]:
         """Execute ``act`` process with output capture and streaming.
 
-        Uses :meth:`ActCommand.display` for the log header. Secret values are
-        written to a ``0600`` temp file and passed via ``--secret-file`` (path
-        only on argv) for workflow ``${{ secrets.* }}``; :attr:`ActCommand.secrets`
-        is also injected into the subprocess environment for act's GitHub auth.
+        Uses :meth:`ActCommand.display` for the log header. Environment and secret
+        values are written to ``0600`` temp files and passed via ``--env-file`` /
+        ``--secret-file`` (paths only on argv). Workflow ``${{ secrets.* }}`` uses
+        the secret file; :attr:`ActCommand.secrets` is also injected into the
+        subprocess environment for act's GitHub auth.
 
         Returns ``(exit_code, stdout, stderr)``.
         """
@@ -567,6 +565,40 @@ class JobExecutor:
             raise TypeError(
                 "ActCommand.secrets must contain only str keys and str values"
             )
+
+        if act_cmd.env and not all(
+            isinstance(k, str) and isinstance(v, str) for k, v in act_cmd.env.items()
+        ):
+            raise TypeError("ActCommand.env must contain only str keys and str values")
+
+        if act_cmd.env:
+            fd, env_path = tempfile.mkstemp(
+                prefix="localci-env-",
+                suffix=".env",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as env_f:
+                    if (
+                        act_cmd.env_file
+                        and act_cmd.env_file.exists()
+                        and not act_cmd._executor_owned_env_file
+                    ):
+                        existing = act_cmd.env_file.read_text(encoding="utf-8")
+                        env_f.write(existing)
+                        if not existing.endswith("\n"):
+                            env_f.write("\n")
+                    for key, value in act_cmd.env.items():
+                        env_f.write(format_secret_file_line(key, value))
+            except Exception:
+                with suppress(OSError):
+                    os.close(fd)
+                with suppress(OSError):
+                    Path(env_path).unlink()
+                raise
+            with suppress(OSError):
+                os.chmod(env_path, 0o600)
+            act_cmd.env_file = Path(env_path)
+            act_cmd._executor_owned_env_file = True
 
         if act_cmd.secrets:
             fd, secret_path = tempfile.mkstemp(
@@ -705,6 +737,14 @@ class JobExecutor:
         if cmd and cmd.event_file and cmd.event_file.exists():
             with suppress(OSError):
                 cmd.event_file.unlink()
+        if (
+            cmd
+            and cmd._executor_owned_env_file
+            and cmd.env_file
+            and cmd.env_file.exists()
+        ):
+            with suppress(OSError):
+                cmd.env_file.unlink()
         if (
             cmd
             and cmd._executor_owned_secret_file

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -29,6 +29,17 @@ _DEFAULT_LOGS_DIR = Path.home() / ".localci" / "logs"
 
 logger = logging.getLogger(__name__)
 
+_INVALID_SECRET_KEY_CHARS = frozenset("=\n\r\0")
+
+
+def _validate_secret_entry(key: str, value: str) -> None:
+    """Reject secret keys/values that would corrupt act's KEY=VALUE secret file."""
+    if any(char in key for char in _INVALID_SECRET_KEY_CHARS):
+        raise ValueError(f"Invalid secret key: {key!r}")
+    if any(char in value for char in "\n\r\0"):
+        raise ValueError(f"Invalid secret value for key {key!r}")
+
+
 # Substrings (matched case-insensitively) for summarizing failed job output.
 _ERROR_EXTRACT_KEYWORDS = (
     "error:",
@@ -172,8 +183,9 @@ class ActCommand:
     # All keys and values must be str (POSIX subprocess.Popen requirement).
     secrets: dict[str, str] = field(default_factory=dict)
     env_file: Path | None = None
-    # Temp file for --secret-file; populated by JobExecutor._execute_process.
+    # Temp file for --secret-file; set by JobExecutor._execute_process only.
     secret_file: Path | None = None
+    _executor_owned_secret_file: bool = field(default=False, repr=False)
 
     # Event
     event_file: Path | None = None
@@ -574,12 +586,16 @@ class JobExecutor:
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as secret_f:
                     for key, value in act_cmd.secrets.items():
+                        _validate_secret_entry(key, value)
                         secret_f.write(f"{key}={value}\n")
             except Exception:
                 with suppress(OSError):
                     os.close(fd)
+                with suppress(OSError):
+                    Path(secret_path).unlink()
                 raise
             act_cmd.secret_file = Path(secret_path)
+            act_cmd._executor_owned_secret_file = True
 
         cmd = act_cmd.build()
 
@@ -696,6 +712,11 @@ class JobExecutor:
         if cmd and cmd.event_file and cmd.event_file.exists():
             with suppress(OSError):
                 cmd.event_file.unlink()
-        if cmd and cmd.secret_file and cmd.secret_file.exists():
+        if (
+            cmd
+            and cmd._executor_owned_secret_file
+            and cmd.secret_file
+            and cmd.secret_file.exists()
+        ):
             with suppress(OSError):
                 cmd.secret_file.unlink()

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -13,6 +13,7 @@ import re
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 from collections.abc import Callable
 from contextlib import suppress
@@ -167,8 +168,12 @@ class ActCommand:
 
     # Environment
     env: dict[str, str] = field(default_factory=dict)
+    # Secrets passed to act via --secret-file (never as argv values).
+    # All keys and values must be str (POSIX subprocess.Popen requirement).
     secrets: dict[str, str] = field(default_factory=dict)
     env_file: Path | None = None
+    # Temp file for --secret-file; populated by JobExecutor._execute_process.
+    secret_file: Path | None = None
 
     # Event
     event_file: Path | None = None
@@ -241,6 +246,10 @@ class ActCommand:
         if self.env_file:
             cmd.extend(["--env-file", str(self.env_file)])
 
+        # Secrets file (path only on argv; values stay in the temp file)
+        if self.secret_file:
+            cmd.extend(["--secret-file", str(self.secret_file)])
+
         # Event payload
         if self.event_file:
             cmd.extend(["-e", str(self.event_file)])
@@ -274,7 +283,7 @@ class ActCommand:
         return cmd
 
     def display(self) -> str:
-        """Human-readable command string (secrets are not included in argv)."""
+        """Human-readable command string (secret values are not included in argv)."""
         return " ".join(self.build())
 
     def __str__(self) -> str:
@@ -537,26 +546,50 @@ class JobExecutor:
     ) -> tuple[int, str, str]:
         """Execute ``act`` process with output capture and streaming.
 
-        Uses :meth:`ActCommand.display` for the log header and injects
-        :attr:`ActCommand.secrets` into the subprocess environment so secrets
-        are never passed on the command line or written to disk.
+        Uses :meth:`ActCommand.display` for the log header. Secret values are
+        written to a ``0600`` temp file and passed via ``--secret-file`` (path
+        only on argv); :attr:`ActCommand.secrets` is also injected into the
+        subprocess environment for act's GitHub authentication.
 
         Returns ``(exit_code, stdout, stderr)``.
         """
-        cmd = act_cmd.build()
         workdir = act_cmd.workdir or Path(".")
         stdout_lines: list[str] = []
         stderr_lines: list[str] = []
         log_lock = threading.Lock()
 
+        if act_cmd.secrets and not all(
+            isinstance(k, str) and isinstance(v, str)
+            for k, v in act_cmd.secrets.items()
+        ):
+            raise TypeError(
+                "ActCommand.secrets must contain only str keys and str values"
+            )
+
+        if act_cmd.secrets:
+            fd, secret_path = tempfile.mkstemp(
+                prefix="localci-secrets-",
+                suffix=".env",
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as secret_f:
+                    for key, value in act_cmd.secrets.items():
+                        secret_f.write(f"{key}={value}\n")
+            except Exception:
+                with suppress(OSError):
+                    os.close(fd)
+                raise
+            act_cmd.secret_file = Path(secret_path)
+
+        cmd = act_cmd.build()
+
         with open(log_file, "w", encoding="utf-8") as log_f:
-            # Write header (argv contains no secrets)
+            # Write header (secret values are not on argv)
             log_f.write("# LocalCI Job Log\n")
             log_f.write(f"# Command: {act_cmd.display()}\n")
             log_f.write(f"# Started: {datetime.now().isoformat()}\n")
             log_f.write(f"# {'=' * 60}\n\n")
 
-            # Inject secrets via subprocess env (never via argv)
             env = dict(os.environ)
             env.update(act_cmd.secrets)
 
@@ -663,3 +696,6 @@ class JobExecutor:
         if cmd and cmd.event_file and cmd.event_file.exists():
             with suppress(OSError):
                 cmd.event_file.unlink()
+        if cmd and cmd.secret_file and cmd.secret_file.exists():
+            with suppress(OSError):
+                cmd.secret_file.unlink()

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -32,12 +32,24 @@ logger = logging.getLogger(__name__)
 _INVALID_SECRET_KEY_CHARS = frozenset("=\n\r\0")
 
 
-def _validate_secret_entry(key: str, value: str) -> None:
-    """Reject secret keys/values that would corrupt act's KEY=VALUE secret file."""
+def _validate_secret_key(key: str) -> None:
+    """Reject secret keys that would corrupt act's godotenv secret file."""
     if any(char in key for char in _INVALID_SECRET_KEY_CHARS):
         raise ValueError(f"Invalid secret key: {key!r}")
-    if any(char in value for char in "\n\r\0"):
+
+
+def _format_secret_file_line(key: str, value: str) -> str:
+    """Format one KEY=VALUE line for act's godotenv ``--secret-file`` parser."""
+    _validate_secret_key(key)
+    if "\0" in value:
         raise ValueError(f"Invalid secret value for key {key!r}")
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+    return f'{key}="{escaped}"\n'
 
 
 # Substrings (matched case-insensitively) for summarizing failed job output.
@@ -586,8 +598,7 @@ class JobExecutor:
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as secret_f:
                     for key, value in act_cmd.secrets.items():
-                        _validate_secret_entry(key, value)
-                        secret_f.write(f"{key}={value}\n")
+                        secret_f.write(_format_secret_file_line(key, value))
             except Exception:
                 with suppress(OSError):
                     os.close(fd)

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -572,8 +572,8 @@ class JobExecutor:
 
         Uses :meth:`ActCommand.display` for the log header. Secret values are
         written to a ``0600`` temp file and passed via ``--secret-file`` (path
-        only on argv); :attr:`ActCommand.secrets` is also injected into the
-        subprocess environment for act's GitHub authentication.
+        only on argv) for workflow ``${{ secrets.* }}``; :attr:`ActCommand.secrets`
+        is also injected into the subprocess environment for act's GitHub auth.
 
         Returns ``(exit_code, stdout, stderr)``.
         """
@@ -605,6 +605,8 @@ class JobExecutor:
                 with suppress(OSError):
                     Path(secret_path).unlink()
                 raise
+            with suppress(OSError):
+                os.chmod(secret_path, 0o600)
             act_cmd.secret_file = Path(secret_path)
             act_cmd._executor_owned_secret_file = True
 
@@ -617,6 +619,8 @@ class JobExecutor:
             log_f.write(f"# Started: {datetime.now().isoformat()}\n")
             log_f.write(f"# {'=' * 60}\n\n")
 
+            # Child environ is visible to same-UID via /proc/<pid>/environ;
+            # issue #58 accepts this over argv for secret delivery.
             env = dict(os.environ)
             env.update(act_cmd.secrets)
 

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -23,34 +23,12 @@ from enum import Enum
 from pathlib import Path
 from typing import IO
 
+from localci.core.secrets_io import format_secret_file_line
 from localci.errors import ActNotFoundError, DockerNotAvailableError
 
 _DEFAULT_LOGS_DIR = Path.home() / ".localci" / "logs"
 
 logger = logging.getLogger(__name__)
-
-_INVALID_SECRET_KEY_CHARS = frozenset("=\n\r\0")
-
-
-def _validate_secret_key(key: str) -> None:
-    """Reject secret keys that would corrupt act's godotenv secret file."""
-    if any(char in key for char in _INVALID_SECRET_KEY_CHARS):
-        raise ValueError(f"Invalid secret key: {key!r}")
-
-
-def _format_secret_file_line(key: str, value: str) -> str:
-    """Format one KEY=VALUE line for act's godotenv ``--secret-file`` parser."""
-    _validate_secret_key(key)
-    if "\0" in value:
-        raise ValueError(f"Invalid secret value for key {key!r}")
-    escaped = (
-        value.replace("\\", "\\\\")
-        .replace('"', '\\"')
-        .replace("\n", "\\n")
-        .replace("\r", "\\r")
-    )
-    return f'{key}="{escaped}"\n'
-
 
 # Substrings (matched case-insensitively) for summarizing failed job output.
 _ERROR_EXTRACT_KEYWORDS = (
@@ -598,7 +576,7 @@ class JobExecutor:
             try:
                 with os.fdopen(fd, "w", encoding="utf-8") as secret_f:
                     for key, value in act_cmd.secrets.items():
-                        secret_f.write(_format_secret_file_line(key, value))
+                        secret_f.write(format_secret_file_line(key, value))
             except Exception:
                 with suppress(OSError):
                     os.close(fd)

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -403,7 +403,6 @@ class ParallelExecutionManager:
                     container_mount_options=container_mount_options,
                 )
 
-            event_file_to_clean: Path | None = None
             try:
                 # Per-job act action cache to avoid parallel jobs sharing ~/.cache/act
                 # (causes "remove ... no such file or directory" when one job cleans cache)
@@ -430,7 +429,6 @@ class ParallelExecutionManager:
                     resolved_cache_paths=resolved_cache_paths,
                     cache_config=self._cache_config,
                 )
-                event_file_to_clean = getattr(cmd, "event_file", None)
                 result = self._executor.run(
                     cmd,
                     matrix_index=job.matrix_entry.index,
@@ -453,15 +451,6 @@ class ParallelExecutionManager:
                         logger.debug(
                             "Could not remove patched workflow temp file %s: %s",
                             workflow_file,
-                            unlink_err,
-                        )
-                if event_file_to_clean is not None:
-                    try:
-                        event_file_to_clean.unlink(missing_ok=True)
-                    except OSError as unlink_err:
-                        logger.debug(
-                            "Could not remove event temp file %s: %s",
-                            event_file_to_clean,
                             unlink_err,
                         )
         except Exception as e:

--- a/cli/localci/core/secrets_io.py
+++ b/cli/localci/core/secrets_io.py
@@ -1,4 +1,4 @@
-"""Godotenv-compatible secret file formatting for act ``--secret-file``."""
+"""Godotenv-compatible dotenv line formatting for act ``--secret-file`` / ``--env-file``."""
 
 from __future__ import annotations
 

--- a/cli/localci/core/secrets_io.py
+++ b/cli/localci/core/secrets_io.py
@@ -1,0 +1,25 @@
+"""Godotenv-compatible secret file formatting for act ``--secret-file``."""
+
+from __future__ import annotations
+
+_INVALID_SECRET_KEY_CHARS = frozenset("=\n\r\0")
+
+
+def validate_secret_key(key: str) -> None:
+    """Reject secret keys that would corrupt act's godotenv secret file."""
+    if any(char in key for char in _INVALID_SECRET_KEY_CHARS):
+        raise ValueError(f"Invalid secret key: {key!r}")
+
+
+def format_secret_file_line(key: str, value: str) -> str:
+    """Format one KEY=VALUE line for act's godotenv ``--secret-file`` parser."""
+    validate_secret_key(key)
+    if "\0" in value:
+        raise ValueError(f"Invalid secret value for key {key!r}")
+    escaped = (
+        value.replace("\\", "\\\\")
+        .replace('"', '\\"')
+        .replace("\n", "\\n")
+        .replace("\r", "\\r")
+    )
+    return f'{key}="{escaped}"\n'

--- a/cli/tests/fixtures/integration/project/.github/workflows/token-test.yml
+++ b/cli/tests/fixtures/integration/project/.github/workflows/token-test.yml
@@ -1,0 +1,19 @@
+name: Token Secret Test
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - name: "Hello"
+            runs-on: ubuntu-latest
+            compiler: gcc
+            version: "15"
+    steps:
+      - run: |
+          if [ -z "${{ secrets.GITHUB_TOKEN }}" ]; then
+            echo "TOKEN_MISSING" && exit 1
+          fi
+          echo "TOKEN_PRESENT"

--- a/cli/tests/integration/test_act_subprocess.py
+++ b/cli/tests/integration/test_act_subprocess.py
@@ -24,6 +24,7 @@ def _build_and_run(
     logs_dir: Path,
     act_runner_image: str,
     project_dir: Path,
+    default_secrets: dict[str, str] | None = None,
 ) -> tuple[JobResult, MatrixEntry]:
     workflow_path = _workflow_path(workflow_name, project_dir)
     analyzer = WorkflowAnalyzer()
@@ -34,6 +35,7 @@ def _build_and_run(
         workflow_file=workflow_path,
         project_dir=project_dir,
         job_id=INTEGRATION_JOB_ID,
+        default_secrets=default_secrets or {},
     )
     cmd = builder.build(entry, image_tag=act_runner_image)
     executor = JobExecutor(logs_dir=logs_dir)
@@ -81,3 +83,22 @@ def test_failing_job_extract_error(
 
     lower = result.error_message.lower()
     assert any(kw in lower for kw in ("failed", "error", "exit"))
+
+
+def test_github_token_available_as_workflow_secret(
+    integration_project: tuple[Path, Path],
+    act_runner_image: str,
+) -> None:
+    project, logs_dir = integration_project
+    result, _ = _build_and_run(
+        "token-test.yml",
+        logs_dir,
+        act_runner_image,
+        project,
+        default_secrets={"GITHUB_TOKEN": "local-ci-test-token"},
+    )
+
+    assert result.status == JobStatus.PASSED
+    combined = (result.stdout or "") + (result.stderr or "")
+    assert "TOKEN_PRESENT" in combined
+    assert "TOKEN_MISSING" not in combined

--- a/cli/tests/integration/test_act_subprocess.py
+++ b/cli/tests/integration/test_act_subprocess.py
@@ -101,6 +101,8 @@ def test_github_token_available_as_workflow_secret(
     assert result.status == JobStatus.PASSED
     assert result.exit_code == 0
     combined = (result.stdout or "") + (result.stderr or "")
-    # act logs the step script (including "TOKEN_MISSING") in combined output;
+    lines = combined.splitlines()
+    # act logs the step script (including echo "TOKEN_MISSING") in combined output;
     # assert on container stdout lines prefixed with "| " instead.
-    assert any("| TOKEN_PRESENT" in line for line in combined.splitlines())
+    assert any("| TOKEN_PRESENT" in line for line in lines)
+    assert not any("| TOKEN_MISSING" in line for line in lines)

--- a/cli/tests/integration/test_act_subprocess.py
+++ b/cli/tests/integration/test_act_subprocess.py
@@ -99,6 +99,8 @@ def test_github_token_available_as_workflow_secret(
     )
 
     assert result.status == JobStatus.PASSED
+    assert result.exit_code == 0
     combined = (result.stdout or "") + (result.stderr or "")
-    assert "TOKEN_PRESENT" in combined
-    assert "TOKEN_MISSING" not in combined
+    # act logs the step script (including "TOKEN_MISSING") in combined output;
+    # assert on container stdout lines prefixed with "| " instead.
+    assert any("| TOKEN_PRESENT" in line for line in combined.splitlines())

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -28,6 +28,8 @@ from localci.core.executor import (
     JobExecutor,
     JobResult,
     JobStatus,
+    _format_secret_file_line,
+    _validate_secret_key,
 )
 from localci.core.results import ExecutionSummary
 from localci.core.workflow import (
@@ -145,6 +147,14 @@ def _make_summary(
 
 class TestActCommand:
     """Test act command construction."""
+
+    def test_format_secret_file_line_quotes_and_escapes(self) -> None:
+        line = _format_secret_file_line("GITHUB_TOKEN", 'ghp_"abc"\nline2')
+        assert line == 'GITHUB_TOKEN="ghp_\\"abc\\"\\nline2"\n'
+
+    def test_validate_secret_key_rejects_invalid_chars(self) -> None:
+        with pytest.raises(ValueError, match="Invalid secret key"):
+            _validate_secret_key("BAD=KEY")
 
     def test_basic_command(self):
         cmd = ActCommand(

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -28,10 +28,9 @@ from localci.core.executor import (
     JobExecutor,
     JobResult,
     JobStatus,
-    _format_secret_file_line,
-    _validate_secret_key,
 )
 from localci.core.results import ExecutionSummary
+from localci.core.secrets_io import format_secret_file_line, validate_secret_key
 from localci.core.workflow import (
     BuildSystem,
     BuildVariant,
@@ -149,12 +148,12 @@ class TestActCommand:
     """Test act command construction."""
 
     def test_format_secret_file_line_quotes_and_escapes(self) -> None:
-        line = _format_secret_file_line("GITHUB_TOKEN", 'ghp_"abc"\nline2')
+        line = format_secret_file_line("GITHUB_TOKEN", 'ghp_"abc"\nline2')
         assert line == 'GITHUB_TOKEN="ghp_\\"abc\\"\\nline2"\n'
 
     def test_validate_secret_key_rejects_invalid_chars(self) -> None:
         with pytest.raises(ValueError, match="Invalid secret key"):
-            _validate_secret_key("BAD=KEY")
+            validate_secret_key("BAD=KEY")
 
     def test_basic_command(self):
         cmd = ActCommand(
@@ -736,7 +735,7 @@ class TestJobExecutor:
         _assert_argv_has_no_secret_leaks(captured_cmd, "secret123")
         assert act_cmd.secret_file is not None
         assert act_cmd.secret_file.exists()
-        assert act_cmd.secret_file.read_text() == _format_secret_file_line(
+        assert act_cmd.secret_file.read_text() == format_secret_file_line(
             "GITHUB_TOKEN", "secret123"
         )
         assert act_cmd._executor_owned_secret_file

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -262,6 +262,21 @@ class TestActCommand:
         assert "--secret" not in args
         assert "secret123" not in args
 
+    def test_secret_file_on_argv_not_values(self, tmp_path):
+        secret_file = tmp_path / "secrets.env"
+        secret_file.write_text("GITHUB_TOKEN=secret123\n")
+        cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            secrets={"GITHUB_TOKEN": "secret123"},
+            secret_file=secret_file,
+        )
+        args = cmd.build()
+        assert "--secret-file" in args
+        assert str(secret_file) in args
+        assert "secret123" not in args
+        assert "--secret" not in args
+
     def test_display_omits_secrets(self):
         cmd = ActCommand(
             workflow_file=Path("ci.yml"),
@@ -674,9 +689,12 @@ class TestJobExecutor:
         mock_process.returncode = 0
 
         captured_env: dict[str, str] = {}
+        captured_cmd: list[str] = []
 
-        def fake_popen(*_args: object, **kwargs: object) -> MagicMock:
-            env = kwargs["env"]
+        def fake_popen(cmd: list[str], **_kwargs: object) -> MagicMock:
+            captured_cmd.extend(cmd)
+            env = _kwargs.get("env")
+            assert env is not None, "subprocess.Popen must receive env kwarg"
             assert isinstance(env, dict)
             captured_env.update(env)
             return mock_process
@@ -692,19 +710,51 @@ class TestJobExecutor:
 
         assert exit_code == 0
         assert captured_env["GITHUB_TOKEN"] == "secret123"
+        assert "--secret-file" in captured_cmd
+        assert "secret123" not in captured_cmd
+        assert act_cmd.secret_file is not None
+        assert act_cmd.secret_file.exists()
         assert "secret123" not in act_cmd.build()
+
+    @patch("shutil.which")
+    def test_secrets_type_guard_rejects_non_str_values(
+        self, mock_which, tmp_path
+    ) -> None:
+        mock_which.return_value = "/usr/bin/act"
+        executor = JobExecutor(logs_dir=self.logs_dir)
+        act_cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            secrets={"GITHUB_TOKEN": 123},  # type: ignore[dict-item]
+            workdir=tmp_path,
+        )
+        with pytest.raises(
+            TypeError, match="ActCommand.secrets must contain only str"
+        ):
+            executor._execute_process(
+                act_cmd,
+                timeout=10,
+                log_file=tmp_path / "job.log",
+                stream_output=False,
+                on_output=None,
+            )
 
     def test_cleanup_temp_files(self, tmp_path):
         event = tmp_path / "event.json"
         event.write_text("{}")
+        secret = tmp_path / "secrets.env"
+        secret.write_text("GITHUB_TOKEN=x\n")
         cmd = ActCommand(
             workflow_file=Path("ci.yml"),
             job_id="build",
             event_file=event,
+            secret_file=secret,
         )
         assert event.exists()
+        assert secret.exists()
         JobExecutor._cleanup_temp_files(cmd)
         assert not event.exists()
+        assert not secret.exists()
 
     def test_cleanup_temp_files_none_cmd(self):
         # Should not raise

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -736,6 +736,9 @@ class TestJobExecutor:
         _assert_argv_has_no_secret_leaks(captured_cmd, "secret123")
         assert act_cmd.secret_file is not None
         assert act_cmd.secret_file.exists()
+        assert act_cmd.secret_file.read_text() == _format_secret_file_line(
+            "GITHUB_TOKEN", "secret123"
+        )
         assert act_cmd._executor_owned_secret_file
         _assert_argv_has_no_secret_leaks(act_cmd.build(), "secret123")
 

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -728,9 +728,7 @@ class TestJobExecutor:
             secrets={"GITHUB_TOKEN": 123},  # type: ignore[dict-item]
             workdir=tmp_path,
         )
-        with pytest.raises(
-            TypeError, match="ActCommand.secrets must contain only str"
-        ):
+        with pytest.raises(TypeError, match="ActCommand.secrets must contain only str"):
             executor._execute_process(
                 act_cmd,
                 timeout=10,

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -48,6 +48,20 @@ from localci.core.workflow import (
 FIXTURES_DIR = Path(__file__).parent / "fixtures"
 
 
+def _assert_argv_has_no_secret_leaks(argv: list[str], *secret_values: str) -> None:
+    """Ensure secret values and ``--secret`` flags never appear on argv."""
+    for arg in argv:
+        assert arg != "--secret", f"unexpected --secret flag in argv: {arg!r}"
+        assert not arg.startswith("--secret="), (
+            f"unexpected --secret= flag in argv: {arg!r}"
+        )
+        for value in secret_values:
+            if value:
+                assert value not in arg, (
+                    f"secret value leaked into argv element: {arg!r}"
+                )
+
+
 def _make_entry(
     *,
     index: int = 0,
@@ -259,8 +273,7 @@ class TestActCommand:
             secrets={"GITHUB_TOKEN": "secret123"},
         )
         args = cmd.build()
-        assert "--secret" not in args
-        assert "secret123" not in args
+        _assert_argv_has_no_secret_leaks(args, "secret123")
 
     def test_secret_file_on_argv_not_values(self, tmp_path):
         secret_file = tmp_path / "secrets.env"
@@ -274,8 +287,7 @@ class TestActCommand:
         args = cmd.build()
         assert "--secret-file" in args
         assert str(secret_file) in args
-        assert "secret123" not in args
-        assert "--secret" not in args
+        _assert_argv_has_no_secret_leaks(args, "secret123")
 
     def test_display_omits_secrets(self):
         cmd = ActCommand(
@@ -285,7 +297,7 @@ class TestActCommand:
         )
         display = cmd.display()
         assert "secret123" not in display
-        assert "--secret" not in display
+        _assert_argv_has_no_secret_leaks(display.split(), "secret123")
 
     def test_container_architecture(self):
         cmd = ActCommand(
@@ -711,10 +723,11 @@ class TestJobExecutor:
         assert exit_code == 0
         assert captured_env["GITHUB_TOKEN"] == "secret123"
         assert "--secret-file" in captured_cmd
-        assert "secret123" not in captured_cmd
+        _assert_argv_has_no_secret_leaks(captured_cmd, "secret123")
         assert act_cmd.secret_file is not None
         assert act_cmd.secret_file.exists()
-        assert "secret123" not in act_cmd.build()
+        assert act_cmd._executor_owned_secret_file
+        _assert_argv_has_no_secret_leaks(act_cmd.build(), "secret123")
 
     @patch("shutil.which")
     def test_secrets_type_guard_rejects_non_str_values(
@@ -752,6 +765,19 @@ class TestJobExecutor:
         assert secret.exists()
         JobExecutor._cleanup_temp_files(cmd)
         assert not event.exists()
+        assert secret.exists()
+
+    def test_cleanup_temp_files_deletes_executor_owned_secret(self, tmp_path):
+        secret = tmp_path / "localci-secrets-owned.env"
+        secret.write_text("GITHUB_TOKEN=x\n")
+        cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            secret_file=secret,
+        )
+        cmd._executor_owned_secret_file = True
+        assert secret.exists()
+        JobExecutor._cleanup_temp_files(cmd)
         assert not secret.exists()
 
     def test_cleanup_temp_files_none_cmd(self):
@@ -818,8 +844,7 @@ class TestActCommandBuilder:
 
         assert cmd.secrets["GITHUB_TOKEN"] == SENTINEL_GITHUB_TOKEN
         argv = cmd.build()
-        assert "--secret" not in argv
-        assert SENTINEL_GITHUB_TOKEN not in argv
+        _assert_argv_has_no_secret_leaks(argv, SENTINEL_GITHUB_TOKEN)
 
     def test_custom_default_secrets(self, tmp_path):
         wf = tmp_path / "ci.yml"
@@ -835,8 +860,7 @@ class TestActCommandBuilder:
         assert cmd.secrets["MY_SECRET"] == "val"
         assert "GITHUB_TOKEN" in cmd.secrets
         argv = cmd.build()
-        assert "--secret" not in argv
-        assert "val" not in argv
+        _assert_argv_has_no_secret_leaks(argv, "val")
 
     def test_x86_architecture(self, tmp_path):
         wf = tmp_path / "ci.yml"

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -252,17 +252,17 @@ class TestActCommand:
         assert "CC=gcc-15" in args
         assert "CXX=g++-15" in args
 
-    def test_secrets(self):
+    def test_secrets_not_on_argv(self):
         cmd = ActCommand(
             workflow_file=Path("ci.yml"),
             job_id="build",
             secrets={"GITHUB_TOKEN": "secret123"},
         )
         args = cmd.build()
-        assert "--secret" in args
-        assert "GITHUB_TOKEN=secret123" in args
+        assert "--secret" not in args
+        assert "secret123" not in args
 
-    def test_display_redacts_secrets(self):
+    def test_display_omits_secrets(self):
         cmd = ActCommand(
             workflow_file=Path("ci.yml"),
             job_id="build",
@@ -270,7 +270,7 @@ class TestActCommand:
         )
         display = cmd.display()
         assert "secret123" not in display
-        assert "***" in display
+        assert "--secret" not in display
 
     def test_container_architecture(self):
         cmd = ActCommand(
@@ -656,6 +656,44 @@ class TestJobExecutor:
         assert "all done" in extracted
         assert "finished ok" in extracted
 
+    @patch("shutil.which")
+    def test_secrets_injected_into_subprocess_env(self, mock_which, tmp_path):
+        mock_which.return_value = "/usr/bin/act"
+        executor = JobExecutor(logs_dir=self.logs_dir)
+        act_cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            secrets={"GITHUB_TOKEN": "secret123"},
+            workdir=tmp_path,
+        )
+        log_file = tmp_path / "job.log"
+
+        mock_process = MagicMock()
+        mock_process.stdout = []
+        mock_process.stderr = []
+        mock_process.returncode = 0
+
+        captured_env: dict[str, str] = {}
+
+        def fake_popen(*_args: object, **kwargs: object) -> MagicMock:
+            env = kwargs["env"]
+            assert isinstance(env, dict)
+            captured_env.update(env)
+            return mock_process
+
+        with patch("localci.core.executor.subprocess.Popen", side_effect=fake_popen):
+            exit_code, _, _ = executor._execute_process(
+                act_cmd,
+                timeout=10,
+                log_file=log_file,
+                stream_output=False,
+                on_output=None,
+            )
+
+        assert exit_code == 0
+        assert captured_env["GITHUB_TOKEN"] == "secret123"
+        assert "secret123" not in act_cmd.build()
+
     def test_cleanup_temp_files(self, tmp_path):
         event = tmp_path / "event.json"
         event.write_text("{}")
@@ -731,6 +769,9 @@ class TestActCommandBuilder:
         cmd = builder.build(entry)
 
         assert cmd.secrets["GITHUB_TOKEN"] == SENTINEL_GITHUB_TOKEN
+        argv = cmd.build()
+        assert "--secret" not in argv
+        assert SENTINEL_GITHUB_TOKEN not in argv
 
     def test_custom_default_secrets(self, tmp_path):
         wf = tmp_path / "ci.yml"
@@ -745,6 +786,9 @@ class TestActCommandBuilder:
 
         assert cmd.secrets["MY_SECRET"] == "val"
         assert "GITHUB_TOKEN" in cmd.secrets
+        argv = cmd.build()
+        assert "--secret" not in argv
+        assert "val" not in argv
 
     def test_x86_architecture(self, tmp_path):
         wf = tmp_path / "ci.yml"

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -264,16 +264,23 @@ class TestActCommand:
         args = cmd.build()
         assert "--rm" in args
 
-    def test_env_vars(self):
+    def test_env_not_on_argv(self, tmp_path):
+        env_file = tmp_path / "job.env"
+        env_file.write_text(
+            format_secret_file_line("CC", "gcc-15")
+            + format_secret_file_line("CXX", "g++-15")
+        )
         cmd = ActCommand(
             workflow_file=Path("ci.yml"),
             job_id="build",
-            env={"CC": "gcc-15", "CXX": "g++-15"},
+            env_file=env_file,
         )
         args = cmd.build()
-        assert "--env" in args
-        assert "CC=gcc-15" in args
-        assert "CXX=g++-15" in args
+        assert "--env-file" in args
+        assert str(env_file) in args
+        assert "--env" not in args
+        assert "CC=gcc-15" not in args
+        assert "CXX=g++-15" not in args
 
     def test_secrets_not_on_argv(self):
         cmd = ActCommand(
@@ -742,6 +749,50 @@ class TestJobExecutor:
         _assert_argv_has_no_secret_leaks(act_cmd.build(), "secret123")
 
     @patch("shutil.which")
+    def test_env_materialized_to_env_file(self, mock_which, tmp_path):
+        mock_which.return_value = "/usr/bin/act"
+        executor = JobExecutor(logs_dir=self.logs_dir)
+        act_cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            env={"CC": "gcc-15", "CXX": "g++-15"},
+            workdir=tmp_path,
+        )
+        log_file = tmp_path / "job.log"
+
+        mock_process = MagicMock()
+        mock_process.stdout = []
+        mock_process.stderr = []
+        mock_process.returncode = 0
+
+        captured_cmd: list[str] = []
+
+        def fake_popen(cmd: list[str], **_kwargs: object) -> MagicMock:
+            captured_cmd.extend(cmd)
+            return mock_process
+
+        with patch("localci.core.executor.subprocess.Popen", side_effect=fake_popen):
+            exit_code, _, _ = executor._execute_process(
+                act_cmd,
+                timeout=10,
+                log_file=log_file,
+                stream_output=False,
+                on_output=None,
+            )
+
+        assert exit_code == 0
+        assert "--env-file" in captured_cmd
+        assert "--env" not in captured_cmd
+        assert "CC=gcc-15" not in captured_cmd
+        assert act_cmd.env_file is not None
+        assert act_cmd.env_file.exists()
+        assert act_cmd.env_file.read_text() == (
+            format_secret_file_line("CC", "gcc-15")
+            + format_secret_file_line("CXX", "g++-15")
+        )
+        assert act_cmd._executor_owned_env_file
+
+    @patch("shutil.which")
     def test_secrets_type_guard_rejects_non_str_values(
         self, mock_which, tmp_path
     ) -> None:
@@ -791,6 +842,19 @@ class TestJobExecutor:
         assert secret.exists()
         JobExecutor._cleanup_temp_files(cmd)
         assert not secret.exists()
+
+    def test_cleanup_temp_files_deletes_executor_owned_env(self, tmp_path):
+        env_file = tmp_path / "localci-env-owned.env"
+        env_file.write_text('CC="gcc-15"\n')
+        cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            env_file=env_file,
+        )
+        cmd._executor_owned_env_file = True
+        assert env_file.exists()
+        JobExecutor._cleanup_temp_files(cmd)
+        assert not env_file.exists()
 
     def test_cleanup_temp_files_none_cmd(self):
         # Should not raise


### PR DESCRIPTION
## Summary

- Remove `--secret GITHUB_TOKEN=...` from `ActCommand.build()` so tokens are not exposed in process argv (`/proc/<pid>/cmdline` on Linux).
- Inject secrets via `env.update(act_cmd.secrets)` in `_execute_process()` before `subprocess.Popen`.
- Simplify `ActCommand.display()` since secrets are no longer in argv.
- Update/add tests: argv omission, display omission, env injection mock, and `ActCommandBuilder` smoke assertions.

## Related issue
- Close https://github.com/cppalliance/local-ci-test-system/issues/58

## Test plan

- [x] `pytest -m "not integration"` (572 passed)
- [x] `ruff check` / `mypy localci/`
- [x] `pytest tests/integration -m integration` (CI — requires act + Docker)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Improved handling of execution secrets: secret values are no longer passed via command-line arguments; they’re provided to the runtime via a secret-file option.
  * Simplified secret-safe command rendering and updated subprocess environment injection to include secrets consistently.
* **Bug Fixes**
  * Adjusted parallel job cleanup to avoid managing the per-job event file.
* **Tests**
  * Expanded unit tests to verify secret redaction, secret-file formatting/validation, env injection, type safety, and correct temp-file cleanup.
  * Added an integration test and workflow to confirm token availability as a workflow secret.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->