### PR TITLE
Remove non-existent MCP server claims from README and Design Guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@ Local CI parses your workflow file, runs selected jobs in containers with pre-bu
 - **Local execution** — Run jobs via act with configurable parallelism
 - **Caching** — ccache, Boost clone, B2 build dir, CMake config, and APT package cache
 - **Pre-built images** — Use or build Docker images per compiler/OS to avoid repeated setup
-- **MCP server** — Optional Model Context Protocol interface for AI/IDE integration
 
 ## Prerequisites
 
@@ -118,7 +117,7 @@ local-ci-test-system/
 ## Documentation
 
 - **[User Guide](cli/Usage%20Guide.md)** — Installation, configuration, commands, troubleshooting
-- **[Design Guide](docs/Design%20Guide.md)** — Architecture, MCP, caching
+- **[Design Guide](docs/Design%20Guide.md)** — Architecture and caching
 - **[Performance and Caching](docs/Performance%20and%20Caching.md)** — Cache layout and config
 - **[Preparation and Plan](docs/Preparation%20and%20Plan.md)** — Implementation plan and issue breakdown
 

--- a/cli/localci/cli/status.py
+++ b/cli/localci/cli/status.py
@@ -1,7 +1,7 @@
 """``localci status`` command.
 
 Show the progress of a running or completed execution.
-Supports MCP-style status from last-status.json and follow mode.
+Supports structured status from last-status.json and follow mode.
 """
 
 from __future__ import annotations
@@ -53,7 +53,7 @@ def status(
     cfg = ctx.obj["config"]
     logs_dir = Path(cfg.logging.directory)
 
-    # Prefer MCP status file when no execution-id specified
+    # Prefer last-status.json when no execution-id specified
     status_file = logs_dir / "last-status.json"
     if not execution_id and status_file.exists():
         try:
@@ -193,7 +193,7 @@ def _job_list(data: dict, key: str) -> list[dict]:
 
 
 def _print_status_table(data: object) -> None:
-    """Render MCP status data as Rich table."""
+    """Render structured status data as Rich table."""
     if not isinstance(data, dict):
         console.print("[bold red]Status data is not a valid dict.[/bold red]")
         return

--- a/cli/localci/core/progress.py
+++ b/cli/localci/core/progress.py
@@ -1,7 +1,7 @@
 """Real-time progress tracking for the parallel execution manager.
 
 Observes the orchestrator via job events and provides Rich Live display,
-JSON status for MCP, and post-execution summary reports.
+JSON status files, and post-execution summary reports.
 """
 
 from __future__ import annotations
@@ -620,11 +620,11 @@ class ProgressTracker:
         console.print()
 
     # -----------------------------------------------------------------------
-    # JSON status (for MCP integration)
+    # JSON status (for localci status --format json)
     # -----------------------------------------------------------------------
 
     def get_status_dict(self) -> dict:
-        """Get structured status for MCP get_status endpoint."""
+        """Get structured status for JSON output and status files."""
         with self._lock:
             jobs = list(self._jobs.values())
 

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -191,7 +191,7 @@ class TestStatus:
         assert result.exit_code == 0
 
     def test_status_uses_last_status_json_and_json_format(self, tmp_path):
-        """When last-status.json exists, status uses MCP schema; --format json outputs it."""
+        """When last-status.json exists, status uses its schema; --format json outputs it."""
         logs_dir = tmp_path / "logs"
         logs_dir.mkdir()
         (logs_dir / "last-status.json").write_text(

--- a/docs/Core Infrastructure.md
+++ b/docs/Core Infrastructure.md
@@ -224,5 +224,5 @@ Full schema and all options are in the [User Guide](../cli/USER_GUIDE.md).
 ## Reference
 
 - **User Guide:** [cli/USER_GUIDE.md](../cli/USER_GUIDE.md) — Installation, all commands, config schema, troubleshooting.
-- **Design Guide:** [Design Guide.md](Design%20Guide.md) — Architecture, MCP, image matching.
+- **Design Guide:** [Design Guide.md](Design%20Guide.md) — Architecture and image matching.
 - **Preparation and Plan:** [Preparation and Plan.md](Preparation%20and%20Plan.md) — Implementation plan and issue breakdown.

--- a/docs/Design Guide.md
+++ b/docs/Design Guide.md
@@ -26,17 +26,11 @@ A system to execute GitHub Actions CI workflows locally with pre-built, optimize
 - Provides real-time progress monitoring
 - Aggregates test results
 
-### MCP Server Interface
-- Exposes endpoints for triggering tests
-- Uses `yq` for workflow analysis
-- Uses `act` for workflow execution
-- Supports async operations for long-running tests
-
 ---
 
 ## Execution Workflow
 
-All steps are performed via scripts within the MCP server.
+All steps are performed via the CLI.
 
 ### Step 1: Extract Workflow Information
 
@@ -151,7 +145,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
 **4.4. Progress Tracking**
 - Track overall progress: `X/Y jobs completed`
 - Track per-job status: `pending`, `running`, `completed`, `failed`
-- Provide real-time updates via MCP interface
+- Provide real-time updates via CLI (`localci status`) and status files
 
 **Output**: Complete execution results for all jobs in test list.
 
@@ -214,86 +208,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
   act --dryrun --matrix compiler:gcc
   ```
 
-### B. MCP Integration
-
-#### MCP Server Endpoints
-
-**`analyze_workflow`**
-- **Purpose**: Execute Step 1 - Analyze workflow files and extract configuration
-- **Input**: 
-  - `workflow_file`: Path to workflow file (e.g., `.github/workflows/ci.yml`)
-  - `event`: Git event name (e.g., `push`, `pull_request`)
-- **Output**: 
-  - `jobs`: List of jobs with their configurations
-  - `matrix_entries`: All matrix combinations
-  - `dependencies`: Job dependency graph
-
-**`run_local_ci`**
-- **Purpose**: Execute Steps 1-4 - Analyze workflows and trigger parallel job execution
-- **Input**:
-  - `workflow_file`: Path to workflow file
-  - `event`: Git event name
-  - `config`: Configuration object (optional)
-    - `jobs`: List of job names to run
-    - `matrix_filters`: Object with key-value pairs to filter matrix (e.g., `{"compiler": "gcc", "version": "15"}`)
-    - `max_parallel`: Maximum concurrent jobs
-    - `job_priorities`: Object mapping job names to priority values (e.g., `{"build": 1, "changelog": 2}`)
-      - Lower number = higher priority (1 is highest)
-      - If not specified, priorities extracted from workflow file or assigned default values
-- **Output**:
-  - `execution_id`: Unique identifier for this execution
-  - `status_url`: URL to check execution status
-
-**`get_status`**
-- **Purpose**: Get execution status (Step 4 progress)
-- **Input**: `execution_id`
-- **Output**:
-  - `progress`: Overall progress (e.g., `25/56 jobs completed`)
-  - `completed_jobs`: List of completed jobs with results
-  - `failed_jobs`: List of failed jobs with error messages
-  - `running_jobs`: List of currently running jobs
-  - `pending_jobs`: List of pending jobs
-
-**`get_logs`**
-- **Purpose**: Get logs for specific job
-- **Input**:
-  - `execution_id`
-  - `job_name`: Name of the job
-  - `matrix_entry`: Matrix entry identifier (optional)
-- **Output**: Job execution logs
-
-**`cancel_execution`**
-- **Purpose**: Cancel running execution
-- **Input**: `execution_id`
-- **Output**: Cancellation status
-
-#### Example MCP Request
-
-```json
-{
-  "tool": "run_local_ci",
-  "input": {
-    "workflow_file": ".github/workflows/ci.yml",
-    "event": "push",
-    "config": {
-      "jobs": ["build"],
-      "matrix_filters": {
-        "compiler": "gcc",
-        "version": "15"
-      },
-      "max_parallel": 20
-    }
-  }
-}
-```
-
-#### Async Operations
-
-- Long-running executions return immediately with `execution_id`
-- Client polls `get_status` endpoint for updates
-- Results available via `get_status` and `get_logs` endpoints
-
-### C. Setup
+### B. Setup
 
 #### Prerequisites
 
@@ -412,7 +327,7 @@ resource_limits:
   disk_min_free_gb: 10  # Minimum free disk space in GB before warning
 ```
 
-### D. Image Matching Algorithm
+### C. Image Matching Algorithm
 
 The algorithm uses a **two-mark system**: essential marks for infrastructure requirements and extra marks for packages/tools.
 
@@ -513,7 +428,7 @@ For each job (matrix_entry):
        → Save new image to registry
 ```
 
-### E. New Image Creation Process
+### D. New Image Creation Process
 
 When no image has full essential marks (= 100), a new image must be created. The image with the highest essential marks is used as the base to minimize build time.
 
@@ -618,7 +533,7 @@ Examples:
 - `beast2-ubuntu-25.04-clang18-asan.tar` (compiler + variant)
 - `beast2-ubuntu-24.04-x86.tar` (specific architecture)
 
-### F. Host Platform Compatibility
+### E. Host Platform Compatibility
 
 **Windows Host:**
 - Windows containers: Run natively
@@ -640,7 +555,7 @@ Examples:
 
 For concrete install commands, Docker Desktop/WSL2 notes, and a preflight checklist before your first run, see **[Cross-platform prerequisites](../cli/Usage%20Guide.md#cross-platform-prerequisites)** in the Usage Guide.
 
-### G. Benefits and Limitations
+### F. Benefits and Limitations
 
 #### Benefits
 
@@ -660,7 +575,7 @@ For concrete install commands, Docker Desktop/WSL2 notes, and a preflight checkl
 - **Initial setup**: Time required to build and save initial image set
 - **Resource intensive**: Requires significant CPU, memory, and disk resources
 
-### H. Resource Requirements
+### G. Resource Requirements
 
 **Minimum Requirements:**
 - CPU: 8 cores (for ~20 parallel jobs)
@@ -674,7 +589,7 @@ For concrete install commands, Docker Desktop/WSL2 notes, and a preflight checkl
 - Disk: 200GB+ (SSD recommended)
 - Network: Fast local storage for image loading
 
-### I. Future Scalability
+### H. Future Scalability
 
 The system can be extended to scale beyond local host limitations using cloud infrastructure and container orchestration:
 
@@ -708,7 +623,7 @@ The system can be extended to scale beyond local host limitations using cloud in
 - **Multi-platform**: Support for mixed Windows/Linux node pools
 
 **Architecture:**
-- **Control Plane**: MCP server + orchestrator controller
+- **Control Plane**: CLI orchestrator controller
 - **Worker Nodes**: Run `act` containers in Kubernetes pods
 - **Image Registry**: Container registry (Docker Hub, GitHub Container Registry, private registry)
 - **Storage**: Persistent volumes for image cache and artifacts
@@ -726,7 +641,7 @@ The system can be extended to scale beyond local host limitations using cloud in
 3. **Phase 3**: Cloud compute instances for heavy workloads
 4. **Phase 4**: Full Kubernetes deployment for enterprise scale
 
-### J. Example Workflow Analysis
+### I. Example Workflow Analysis
 
 **Beast2 CI Workflow Example:**
 - **Total jobs**: 4 (runner-selection, build, changelog, antora)

--- a/docs/Design Guide.md
+++ b/docs/Design Guide.md
@@ -9,11 +9,13 @@ A system to execute GitHub Actions CI workflows locally with pre-built, optimize
 ## Architecture Components
 
 ### CI Workflow Analyzer
+
 - Uses `yq` for parsing GitHub Actions YAML files
 - Extracts jobs, matrix configurations, steps, dependencies
 - Identifies OS/container requirements, compiler versions, packages
 
 ### Image Management System
+
 - Maintains registry of pre-built Docker images (stored as `.tar` files)
 - Implements image matching algorithm to select optimal images
 - Creates new images on-demand during job execution when no matching image exists
@@ -21,6 +23,7 @@ A system to execute GitHub Actions CI workflows locally with pre-built, optimize
 - Removes old images to manage disk space
 
 ### Test Orchestrator
+
 - Coordinates parallel test execution (~20 jobs simultaneously)
 - Uses Docker API to manage containers
 - Provides real-time progress monitoring
@@ -55,6 +58,7 @@ Determine which jobs and matrix entries to execute from configuration file:
 - Create ordered list of (job, matrix_entry, priority) tuples, sorted by priority (highest first)
 
 **Priority Rules:**
+
 - Jobs with higher priority must complete before lower priority jobs can start
 - Within same priority level, jobs can run in parallel (up to parallel limit)
 - Priority can be extracted from workflow file or assigned via configuration
@@ -66,11 +70,13 @@ Determine which jobs and matrix entries to execute from configuration file:
 For each (job, matrix_entry) pair in the test list, determine required Docker image:
 
 **3.1. Identify Required Docker Image Type**
+
 - Container image (from `matrix.container` or `job.container.image`)
 - Runner OS (from `matrix.runs-on` or `job.runs-on`)
 - Additional requirements (compiler versions, packages, architecture)
 
 **3.2. Match with Image Registry**
+
 - Use two-mark Image Matching Algorithm to evaluate all available images
 - Calculate essential marks (OS, compiler) and extra marks (packages, tools)
 - Record execution plan:
@@ -86,6 +92,7 @@ Execute jobs with parallel control and priority-based resource management. Jobs 
 For each job, prepare image (load or build) and execute `act`. If an image doesn't exist, it is built synchronously before the job runs - jobs are never skipped due to missing images.
 
 **4.1. Parallel Execution Manager**
+
 - Set maximum concurrent jobs (e.g., ~20 parallel)
 - Monitor resource usage (CPU, memory, disk)
 - Maintain priority-ordered queue of pending (job, matrix_entry, priority) tuples
@@ -97,6 +104,7 @@ For each job, prepare image (load or build) and execute `act`. If an image doesn
 For each job ready to execute (when under parallel limit AND priority allows):
 
 **Priority Check:**
+
 - Job can only start if:
   1. Under parallel limit (e.g., < 20 running jobs)
   2. No higher priority jobs are running (all higher priority jobs completed)
@@ -131,6 +139,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
    - Unload Docker image to free memory
 
 **4.3. Job Completion Handling**
+
 - When one job completes:
   - Remove from running jobs list
   - Add results to completed jobs
@@ -143,6 +152,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
   - Update progress tracking
 
 **4.4. Progress Tracking**
+
 - Track overall progress: `X/Y jobs completed`
 - Track per-job status: `pending`, `running`, `completed`, `failed`
 - Provide real-time updates via CLI (`localci status`) and status files
@@ -156,6 +166,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
 ### A. Tools
 
 #### `yq`
+
 - **Purpose**: Parse and analyze GitHub Actions YAML workflow files
 - **Installation**:
   - Windows: `choco install yq` or download from GitHub releases
@@ -163,6 +174,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
   - macOS: `brew install yq`
 - **Usage**: Extract jobs, matrix configurations, dependencies, container requirements
 - **Example commands**:
+
   ```bash
   # Extract all jobs
   yq '.jobs' .github/workflows/ci.yml
@@ -178,6 +190,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
   ```
 
 #### `act`
+
 - **Purpose**: Execute GitHub Actions workflows locally in Docker containers
 - **Installation**:
   - Windows: `choco install act-cli` or download from GitHub releases
@@ -192,6 +205,7 @@ For each job ready to execute (when under parallel limit AND priority allows):
   - `--action-offline-mode`: Use cached actions only
   - `--dryrun`: Preview without executing
 - **Example commands**:
+
   ```bash
   # Run specific job with matrix filter
   act -W .github/workflows/ci.yml \
@@ -278,6 +292,7 @@ images:
 ```
 
 **Image Registry Operations:**
+
 ```bash
 # Load image from tar file
 docker load -i images/beast2/ubuntu-25.04-base.tar
@@ -301,7 +316,7 @@ Create `local-ci-config.yml`:
 jobs:
   - name: build
     enabled: true
-    priority: 1  # Higher priority = execute first (1 is highest)
+    priority: 1 # Higher priority = execute first (1 is highest)
     matrix_filters:
       - compiler: gcc
         version: 15
@@ -310,7 +325,7 @@ jobs:
 
   - name: changelog
     enabled: true
-    priority: 2  # Lower priority, waits for priority 1 jobs
+    priority: 2 # Lower priority, waits for priority 1 jobs
 
   - name: antora
     enabled: false
@@ -322,9 +337,9 @@ resource_limits:
   cpu_per_job: 2
   memory_per_job: 4GB
   disk_per_job: 10GB
-  cpu_threshold: 90  # Pause new jobs if CPU usage exceeds this percentage
-  memory_threshold: 85  # Pause new jobs if memory usage exceeds this percentage
-  disk_min_free_gb: 10  # Minimum free disk space in GB before warning
+  cpu_threshold: 90 # Pause new jobs if CPU usage exceeds this percentage
+  memory_threshold: 85 # Pause new jobs if memory usage exceeds this percentage
+  disk_min_free_gb: 10 # Minimum free disk space in GB before warning
 ```
 
 ### C. Image Matching Algorithm
@@ -338,6 +353,7 @@ The algorithm uses a **two-mark system**: essential marks for infrastructure req
 **Essential Marks (Infrastructure - Maximum 100 points):**
 
 Extracted from matrix entry:
+
 - OS type, version, and architecture (combined): from `container: "ubuntu:25.04"` and `x86: true/false` → ubuntu:25.04+x86_64 or ubuntu:25.04+i386
 - Compiler family and version: from `compiler: "gcc"`, `version: "15"` → gcc-15
 
@@ -357,6 +373,7 @@ Essential marks are calculated sequentially - if any earlier check fails, stop:
    - Example: OS+version+arch matched but gcc-15 ≠ gcc-14 → Essential mark = 70
 
 **Essential marks possible values: 0, 70, 100**
+
 - **Essential mark = 0**: OS+version+architecture mismatch (incompatible, cannot use as base)
 - **Essential mark = 70**: OS+version+architecture match, but compiler differs (can use as base, upgrade compiler)
 - **Essential mark = 100**: All infrastructure matches exactly (full match)
@@ -364,10 +381,12 @@ Essential marks are calculated sequentially - if any earlier check fails, stop:
 **Extra Marks (Packages/Tools - Maximum 100+ points):**
 
 Extracted from matrix entry:
+
 - Required packages: from `install: "gcc-15-multilib libssl-dev zlib1g-dev"`
 - Build tools: from `build-cmake: true` → cmake required
 
 Scoring:
+
 1. **Required Packages Present**: +10 points per package
    - Typical: 5-10 packages = 50-100 points
 
@@ -389,6 +408,7 @@ Scoring:
    - Install all required packages
 
 **Tie-Breaking (same total marks):**
+
 - Prefer most recently used (`last_used` timestamp)
 - Prefer highest usage count (`usage_count`)
 - Prefer smallest size (`size_mb`)
@@ -432,7 +452,7 @@ For each job (matrix_entry):
 
 When no image has full essential marks (= 100), a new image must be created. The image with the highest essential marks is used as the base to minimize build time.
 
-**E.1. Select Base Image**
+**D.1. Select Base Image**
 
 If no images have essential marks = 100, select base by highest essential marks:
 
@@ -450,11 +470,12 @@ If no images have essential marks = 100, select base by highest essential marks:
    - Prefer 70 over 0 (can reuse OS+version+architecture setup)
    - If tie at 70, use tie-breaking (recently used, usage count, size)
 
-**E.2. Build New Image**
+**D.2. Build New Image**
 
 When building new image (essential marks < 100):
 
 **If base has essential marks = 70:**
+
 ```dockerfile
 # Load base image with matching OS+version+architecture
 docker load -i <base-image>.tar
@@ -479,6 +500,7 @@ docker save -o <new-image>.tar <new-image>:latest
 ```
 
 **If no base available (essential marks = 0):**
+
 ```dockerfile
 # Pull official base matching OS+version+architecture
 docker pull ubuntu:25.04  # or i386/ubuntu:25.04 for x86
@@ -501,7 +523,7 @@ docker build -t <new-image>:latest .
 docker save -o <new-image>.tar <new-image>:latest
 ```
 
-**E.3. Update Image Registry**
+**D.3. Update Image Registry**
 
 After creating new image, update registry:
 
@@ -524,11 +546,12 @@ After creating new image, update registry:
   usage_count: 0
 ```
 
-**E.4. Image Naming Convention**
+**D.4. Image Naming Convention**
 
 New images should follow naming pattern: `<project>-<os>-<variant>.tar`
 
 Examples:
+
 - `beast2-ubuntu-25.04-gcc15.tar` (specific compiler)
 - `beast2-ubuntu-25.04-clang18-asan.tar` (compiler + variant)
 - `beast2-ubuntu-24.04-x86.tar` (specific architecture)
@@ -536,17 +559,20 @@ Examples:
 ### E. Host Platform Compatibility
 
 **Windows Host:**
+
 - Windows containers: Run natively
 - Linux containers: Run via Docker Desktop (WSL2 backend)
 - Parallel execution: Both container types can run simultaneously
 - macOS containers: Not supported (macOS not containerized)
 
 **Linux Host:**
+
 - Linux containers: Run natively
 - Windows containers: Not supported (requires Windows host)
 - macOS containers: Not supported
 
 **macOS Host:**
+
 - Linux containers: Run via Docker Desktop
 - Windows containers: Not supported
 - macOS containers: Not supported (requires full VM)
@@ -578,12 +604,14 @@ For concrete install commands, Docker Desktop/WSL2 notes, and a preflight checkl
 ### G. Resource Requirements
 
 **Minimum Requirements:**
+
 - CPU: 8 cores (for ~20 parallel jobs)
 - RAM: 32GB (4GB per job × 8 concurrent)
 - Disk: 100GB (for images, containers, build artifacts)
 - Docker: Docker Desktop with WSL2 (Windows) or Docker Engine (Linux)
 
 **Recommended Requirements:**
+
 - CPU: 16+ cores
 - RAM: 64GB+
 - Disk: 200GB+ (SSD recommended)
@@ -596,12 +624,14 @@ The system can be extended to scale beyond local host limitations using cloud in
 #### Cloud-Based Execution
 
 **Cloud Storage for Images:**
+
 - Store pre-built Docker images in cloud object storage (AWS S3, Azure Blob Storage, Google Cloud Storage)
 - Download images on-demand to cloud compute instances
 - Reduce local storage requirements
 - Enable sharing images across multiple developers/teams
 
 **Cloud Compute Instances:**
+
 - Run CI jobs on cloud VMs (AWS EC2, Azure VMs, Google Compute Engine)
 - Scale compute resources based on workload
 - Pay-per-use model for occasional large test runs
@@ -610,12 +640,14 @@ The system can be extended to scale beyond local host limitations using cloud in
 #### Kubernetes Orchestration
 
 **Kubernetes Cluster:**
+
 - Deploy test orchestrator as Kubernetes controller
 - Run each job as a Kubernetes Pod
 - Automatic scaling based on queue length
 - Resource management via Kubernetes resource limits
 
 **Benefits:**
+
 - **Horizontal scaling**: Add worker nodes to increase capacity
 - **High availability**: Automatic pod restart on failures
 - **Resource efficiency**: Better utilization of cluster resources
@@ -623,12 +655,14 @@ The system can be extended to scale beyond local host limitations using cloud in
 - **Multi-platform**: Support for mixed Windows/Linux node pools
 
 **Architecture:**
+
 - **Control Plane**: CLI orchestrator controller
 - **Worker Nodes**: Run `act` containers in Kubernetes pods
 - **Image Registry**: Container registry (Docker Hub, GitHub Container Registry, private registry)
 - **Storage**: Persistent volumes for image cache and artifacts
 
 **Implementation Considerations:**
+
 - Replace Docker API calls with Kubernetes API
 - Use Kubernetes Jobs for one-time test executions
 - Use ConfigMaps/Secrets for configuration management
@@ -636,6 +670,7 @@ The system can be extended to scale beyond local host limitations using cloud in
 - Use Kubernetes CronJobs for scheduled test runs
 
 **Migration Path:**
+
 1. **Phase 1**: Local execution (current implementation)
 2. **Phase 2**: Hybrid - local + cloud storage for images
 3. **Phase 3**: Cloud compute instances for heavy workloads
@@ -644,6 +679,7 @@ The system can be extended to scale beyond local host limitations using cloud in
 ### I. Example Workflow Analysis
 
 **Beast2 CI Workflow Example:**
+
 - **Total jobs**: 4 (runner-selection, build, changelog, antora)
 - **Build job matrix**: 56 configurations
   - Windows: 7 variants
@@ -652,6 +688,7 @@ The system can be extended to scale beyond local host limitations using cloud in
 - **Total job instances**: 61 (1 + 56 + 1 + 3)
 
 **Matrix breakdown:**
+
 - GCC versions: 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15
 - Clang versions: 3.9, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20
 - Container images: ubuntu:18.04, ubuntu:20.04, ubuntu:22.04, ubuntu:24.04, ubuntu:25.04

--- a/docs/Parallel Execution and Orchestration.md
+++ b/docs/Parallel Execution and Orchestration.md
@@ -24,7 +24,7 @@ Together, these are the **orchestrator** and **parallel execution** features: th
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                      MCP / CLI                                    │
+│                      CLI                                          │
 └─────────────────────┬───────────────────────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────────────────────┐
@@ -121,16 +121,16 @@ While a run is in progress, Local CI shows:
 - **Priority levels** and how many jobs in each level have completed.
 - **Overall progress** (e.g. “5/10 jobs completed”).
 
-When the run finishes, it prints a **summary**: total duration, pass/fail counts, and a table of each job with result and duration. It also writes machine-readable output (e.g. `last-run.json`, `last-status.json`) for use by `localci status` and by the MCP server.
+When the run finishes, it prints a **summary**: total duration, pass/fail counts, and a table of each job with result and duration. It also writes machine-readable output (e.g. `last-run.json`, `last-status.json`) for use by `localci status`.
 
 ### How you use it
 
 - **During run:** Just run `localci run ...`; the live display updates automatically. No extra flags needed.
 - **After run:** `localci status` shows the status of the last run (or a specific execution by ID). Use `localci status --format json` for scriptable output. Logs for a specific job: `localci logs <job>` (e.g. by index or name).
 
-### Status file and MCP
+### Status file
 
-The orchestrator (or progress tracker) writes a status file (e.g. `last-status.json`) during and after the run. It includes execution ID, start time, duration, per-job status, and optional current step. The MCP server’s `get_status` endpoint can expose this so that IDEs or agents can query run status without parsing the terminal.
+The orchestrator (or progress tracker) writes a status file (e.g. `last-status.json`) during and after the run. It includes execution ID, start time, duration, per-job status, and optional current step. Use `localci status` (or `localci status --format json`) to query run status without parsing the terminal.
 
 ---
 

--- a/docs/Performance and Caching.md
+++ b/docs/Performance and Caching.md
@@ -24,7 +24,7 @@ With caches warm, full Linux CI can complete in under ~2 minutes and incremental
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                      MCP / CLI                                    │
+│                      CLI                                          │
 └─────────────────────┬───────────────────────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────────────────────┐
@@ -239,5 +239,5 @@ cache:
 ## Reference
 
 - Implementation plan and issue breakdown: [Preparation and Plan](Preparation%20and%20Plan.md).
-- Architecture and MCP: [Design Guide](Design%20Guide.md).
+- Architecture: [Design Guide](Design%20Guide.md).
 - Config reference and troubleshooting: [User Guide](../cli/USER_GUIDE.md).

--- a/docs/Preparation and Plan.md
+++ b/docs/Preparation and Plan.md
@@ -36,8 +36,8 @@ Analyzed the Local CI System Design document and capy's GitHub Actions workflow 
 
 ```text
 ┌─────────────────────────────────────────────────────────────────┐
-│                      MCP Server Interface                        │
-│  analyze_workflow | run_local_ci | get_status | get_logs        │
+│                      CLI                                         │
+│  analyze | list | run | status | logs | images | cache | config  │
 └─────────────────────┬───────────────────────────────────────────┘
                       │
 ┌─────────────────────▼───────────────────────────────────────────┐
@@ -230,24 +230,9 @@ Analyzed the Local CI System Design document and capy's GitHub Actions workflow 
 
 ---
 
-### Phase 6: MCP Integration - Priority: Medium
+### Phase 6: Developer Experience - Priority: Low
 
-#### Issue 15: MCP Server Endpoints
-**Scope**: Expose local CI via MCP for AI agent integration
-**Deliverables**:
-- `analyze_workflow` endpoint
-- `run_local_ci` endpoint
-- `get_status` endpoint
-- `get_logs` endpoint
-- Async operation support
-**Dependencies**: Issues 1-8
-**Estimate**: MCP integration
-
----
-
-### Phase 7: Developer Experience - Priority: Low
-
-#### Issue 16: Configuration File Support
+#### Issue 15: Configuration File Support
 **Scope**: Project-specific configuration
 **Deliverables**:
 - `.localci.yml` schema
@@ -258,7 +243,7 @@ Analyzed the Local CI System Design document and capy's GitHub Actions workflow 
 **Dependencies**: Issue 1
 **Estimate**: Config system
 
-#### Issue 17: IDE Integration (VS Code/Cursor)
+#### Issue 16: IDE Integration (VS Code/Cursor)
 **Scope**: Integrate with developer IDEs
 **Deliverables**:
 - VS Code extension or tasks.json templates
@@ -291,8 +276,7 @@ Analyzed the Local CI System Design document and capy's GitHub Actions workflow 
 
 ### Sprint 4: Platform Expansion
 13. Issue 13: Windows Support
-14. Issue 15: MCP Server Endpoints
-15. Issue 16: Configuration File Support
+14. Issue 15: Configuration File Support
 
 ---
 


### PR DESCRIPTION
## Summary

Documentation described an MCP server interface (five endpoints, JSON API, async polling) that is not implemented in the codebase. This PR removes those claims so the docs match what `localci` actually ships: a CLI.

- **README.md:** Removed the MCP server feature bullet; updated the Design Guide link description.
- **docs/Design Guide.md:** Removed the MCP Server Interface section and the MCP Integration appendix; rewrote execution/progress text to reference the CLI; renumbered appendices B–I; updated Future Scalability control-plane wording.

Docs-only change; no code or behavior changes.

## Test plan

- [x] `grep -i mcp README.md docs/Design\ Guide.md` returns no matches
- [x] Appendix headings in Design Guide are sequential (A–I)
- [ ] Existing test suite passes (no code changes expected to affect tests)

## Related Issues
- Close https://github.com/cppalliance/local-ci-test-system/issues/60

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the Design Guide to use a CLI-driven local CI execution workflow and replaced the prior MCP integration appendix with a new setup section.
  * Refreshed architecture and scalability docs (including diagram labels) to reflect a CLI-oriented control-plane and CLI-based real-time progress/status via status files.
  * Updated the Features list to remove the “MCP server” item and adjusted related reference text/link descriptions.
  * Reorganized/renumbered sections across the guide for consistency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->