### PR TITLE
Add psutil to runtime dependencies

### DIFF
--- a/cli/localci/utils/resources.py
+++ b/cli/localci/utils/resources.py
@@ -60,8 +60,8 @@ class ResourceMonitor:
             return psutil
         except ImportError:
             logger.warning(
-                "psutil not installed. Resource monitoring will use estimates. "
-                "Install with: pip install psutil"
+                "psutil not available. Resource monitoring will use estimates. "
+                "Reinstall localci to restore full resource monitoring."
             )
             return None
 

--- a/cli/pyproject.toml
+++ b/cli/pyproject.toml
@@ -11,6 +11,7 @@ license = "BSL-1.0"
 requires-python = ">=3.10"
 dependencies = [
     "click>=8.1.0",
+    "psutil>=5.9.0",
     "pyyaml>=6.0",
     "rich>=13.0.0",
     "pydantic>=2.0.0",

--- a/cli/tests/test_orchestrator.py
+++ b/cli/tests/test_orchestrator.py
@@ -286,32 +286,3 @@ class TestParallelExecutionManager:
         assert status["state"] in ("completed", "running")
         assert "total_jobs" in status
         assert "resources" in status
-
-
-# ---------------------------------------------------------------------------
-# ResourceMonitor
-# ---------------------------------------------------------------------------
-
-
-class TestResourceMonitor:
-    @patch("localci.utils.resources.ResourceMonitor._try_import_psutil")
-    def test_snapshot_without_psutil(self, mock_import):
-        mock_import.return_value = None
-        from localci.utils.resources import ResourceMonitor
-
-        monitor = ResourceMonitor()
-        snap = monitor.snapshot()
-        assert snap.cpu_percent == 50.0
-        assert snap.memory_percent == 50.0
-
-    def test_check_thresholds_healthy(self):
-        from localci.utils.resources import ResourceMonitor
-
-        monitor = ResourceMonitor()
-        ok, warnings = monitor.check_thresholds(
-            cpu_threshold=100.0,
-            memory_threshold=100.0,
-            disk_min_gb=0.0,
-        )
-        assert ok is True
-        assert len(warnings) == 0

--- a/cli/tests/test_resources.py
+++ b/cli/tests/test_resources.py
@@ -1,0 +1,69 @@
+"""Tests for ResourceMonitor (Issue 4)."""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from localci.utils.resources import ResourceMonitor
+
+
+class TestResourceMonitor:
+    @patch("localci.utils.resources.subprocess.run")
+    @patch("localci.utils.resources.ResourceMonitor._try_import_psutil")
+    def test_snapshot_with_psutil(self, mock_import, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="")
+        mock_psutil = MagicMock()
+        mock_psutil.cpu_percent.return_value = 42.0
+        mem = MagicMock()
+        mem.percent = 60.0
+        mem.available = 4 * 1024**3
+        mock_psutil.virtual_memory.return_value = mem
+        disk = MagicMock()
+        disk.free = 100 * 1024**3
+        mock_psutil.disk_usage.return_value = disk
+        mock_import.return_value = mock_psutil
+
+        monitor = ResourceMonitor()
+        snap = monitor.snapshot()
+
+        assert snap.cpu_percent == 42.0
+        assert snap.memory_percent == 60.0
+        assert snap.memory_available_gb == pytest.approx(4.0)
+        assert snap.disk_free_gb == pytest.approx(100.0)
+
+    @patch("localci.utils.resources.subprocess.run")
+    @patch("localci.utils.resources.ResourceMonitor._try_import_psutil")
+    def test_snapshot_without_psutil_uses_estimates(self, mock_import, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="")
+        mock_import.return_value = None
+
+        monitor = ResourceMonitor()
+        snap = monitor.snapshot()
+
+        assert snap.cpu_percent == 50.0
+        assert snap.memory_percent == 50.0
+        assert snap.disk_free_gb == 50.0
+
+    def test_import_error_emits_warning(self, caplog):
+        with (
+            patch.dict(sys.modules, {"psutil": None}),
+            caplog.at_level(logging.WARNING, logger="localci.utils.resources"),
+        ):
+            monitor = ResourceMonitor()
+
+        assert "psutil" in caplog.text
+        assert monitor._psutil is None
+
+    def test_check_thresholds_healthy(self):
+        monitor = ResourceMonitor()
+        ok, warnings = monitor.check_thresholds(
+            cpu_threshold=100.0,
+            memory_threshold=100.0,
+            disk_min_gb=0.0,
+        )
+        assert ok is True
+        assert len(warnings) == 0

--- a/cli/tests/test_resources.py
+++ b/cli/tests/test_resources.py
@@ -58,7 +58,21 @@ class TestResourceMonitor:
         assert "psutil" in caplog.text
         assert monitor._psutil is None
 
-    def test_check_thresholds_healthy(self):
+    @patch("localci.utils.resources.subprocess.run")
+    @patch("localci.utils.resources.ResourceMonitor._try_import_psutil")
+    def test_check_thresholds_healthy(self, mock_import, mock_subprocess):
+        mock_subprocess.return_value = MagicMock(returncode=0, stdout="")
+        mock_psutil = MagicMock()
+        mock_psutil.cpu_percent.return_value = 42.0
+        mem = MagicMock()
+        mem.percent = 60.0
+        mem.available = 4 * 1024**3
+        mock_psutil.virtual_memory.return_value = mem
+        disk = MagicMock()
+        disk.free = 100 * 1024**3
+        mock_psutil.disk_usage.return_value = disk
+        mock_import.return_value = mock_psutil
+
         monitor = ResourceMonitor()
         ok, warnings = monitor.check_thresholds(
             cpu_threshold=100.0,

--- a/cli/tests/test_resources.py
+++ b/cli/tests/test_resources.py
@@ -1,4 +1,4 @@
-"""Tests for ResourceMonitor (Issue 4)."""
+"""Tests for ResourceMonitor."""
 
 from __future__ import annotations
 
@@ -56,6 +56,7 @@ class TestResourceMonitor:
             monitor = ResourceMonitor()
 
         assert "psutil" in caplog.text
+        assert "Reinstall localci" in caplog.text
         assert monitor._psutil is None
 
     @patch("localci.utils.resources.subprocess.run")

--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -342,6 +342,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "psutil" },
     { name = "pydantic" },
     { name = "pyyaml" },
     { name = "rich" },
@@ -363,6 +364,7 @@ requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.10.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=4.0.0" },
+    { name = "psutil", specifier = ">=5.9.0" },
     { name = "pydantic", specifier = ">=2.0.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=7.0.0" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=4.0.0" },
@@ -522,6 +524,34 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "psutil"
+version = "7.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/c6/d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/psutil-7.2.2.tar.gz", hash = "sha256:0746f5f8d406af344fd547f1c8daa5f5c33dbc293bb8d6a16d80b4bb88f59372", size = 493740, upload-time = "2026-01-28T18:14:54.428Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/08/510cbdb69c25a96f4ae523f733cdc963ae654904e8db864c07585ef99875/psutil-7.2.2-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:2edccc433cbfa046b980b0df0171cd25bcaeb3a68fe9022db0979e7aa74a826b", size = 130595, upload-time = "2026-01-28T18:14:57.293Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/f5/97baea3fe7a5a9af7436301f85490905379b1c6f2dd51fe3ecf24b4c5fbf/psutil-7.2.2-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78c8603dcd9a04c7364f1a3e670cea95d51ee865e4efb3556a3a63adef958ea", size = 131082, upload-time = "2026-01-28T18:14:59.732Z" },
+    { url = "https://files.pythonhosted.org/packages/37/d6/246513fbf9fa174af531f28412297dd05241d97a75911ac8febefa1a53c6/psutil-7.2.2-cp313-cp313t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1a571f2330c966c62aeda00dd24620425d4b0cc86881c89861fbc04549e5dc63", size = 181476, upload-time = "2026-01-28T18:15:01.884Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/b5/9182c9af3836cca61696dabe4fd1304e17bc56cb62f17439e1154f225dd3/psutil-7.2.2-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:917e891983ca3c1887b4ef36447b1e0873e70c933afc831c6b6da078ba474312", size = 184062, upload-time = "2026-01-28T18:15:04.436Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ba/0756dca669f5a9300d0cbcbfae9a4c30e446dfc7440ffe43ded5724bfd93/psutil-7.2.2-cp313-cp313t-win_amd64.whl", hash = "sha256:ab486563df44c17f5173621c7b198955bd6b613fb87c71c161f827d3fb149a9b", size = 139893, upload-time = "2026-01-28T18:15:06.378Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/61/8fa0e26f33623b49949346de05ec1ddaad02ed8ba64af45f40a147dbfa97/psutil-7.2.2-cp313-cp313t-win_arm64.whl", hash = "sha256:ae0aefdd8796a7737eccea863f80f81e468a1e4cf14d926bd9b6f5f2d5f90ca9", size = 135589, upload-time = "2026-01-28T18:15:08.03Z" },
+    { url = "https://files.pythonhosted.org/packages/81/69/ef179ab5ca24f32acc1dac0c247fd6a13b501fd5534dbae0e05a1c48b66d/psutil-7.2.2-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:eed63d3b4d62449571547b60578c5b2c4bcccc5387148db46e0c2313dad0ee00", size = 130664, upload-time = "2026-01-28T18:15:09.469Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/64/665248b557a236d3fa9efc378d60d95ef56dd0a490c2cd37dafc7660d4a9/psutil-7.2.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7b6d09433a10592ce39b13d7be5a54fbac1d1228ed29abc880fb23df7cb694c9", size = 131087, upload-time = "2026-01-28T18:15:11.724Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2e/e6782744700d6759ebce3043dcfa661fb61e2fb752b91cdeae9af12c2178/psutil-7.2.2-cp314-cp314t-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fa4ecf83bcdf6e6c8f4449aff98eefb5d0604bf88cb883d7da3d8d2d909546a", size = 182383, upload-time = "2026-01-28T18:15:13.445Z" },
+    { url = "https://files.pythonhosted.org/packages/57/49/0a41cefd10cb7505cdc04dab3eacf24c0c2cb158a998b8c7b1d27ee2c1f5/psutil-7.2.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e452c464a02e7dc7822a05d25db4cde564444a67e58539a00f929c51eddda0cf", size = 185210, upload-time = "2026-01-28T18:15:16.002Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/2c/ff9bfb544f283ba5f83ba725a3c5fec6d6b10b8f27ac1dc641c473dc390d/psutil-7.2.2-cp314-cp314t-win_amd64.whl", hash = "sha256:c7663d4e37f13e884d13994247449e9f8f574bc4655d509c3b95e9ec9e2b9dc1", size = 141228, upload-time = "2026-01-28T18:15:18.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/fc/f8d9c31db14fcec13748d373e668bc3bed94d9077dbc17fb0eebc073233c/psutil-7.2.2-cp314-cp314t-win_arm64.whl", hash = "sha256:11fe5a4f613759764e79c65cf11ebdf26e33d6dd34336f8a337aa2996d71c841", size = 136284, upload-time = "2026-01-28T18:15:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/36/5ee6e05c9bd427237b11b3937ad82bb8ad2752d72c6969314590dd0c2f6e/psutil-7.2.2-cp36-abi3-macosx_10_9_x86_64.whl", hash = "sha256:ed0cace939114f62738d808fdcecd4c869222507e266e574799e9c0faa17d486", size = 129090, upload-time = "2026-01-28T18:15:22.168Z" },
+    { url = "https://files.pythonhosted.org/packages/80/c4/f5af4c1ca8c1eeb2e92ccca14ce8effdeec651d5ab6053c589b074eda6e1/psutil-7.2.2-cp36-abi3-macosx_11_0_arm64.whl", hash = "sha256:1a7b04c10f32cc88ab39cbf606e117fd74721c831c98a27dc04578deb0c16979", size = 129859, upload-time = "2026-01-28T18:15:23.795Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/70/5d8df3b09e25bce090399cf48e452d25c935ab72dad19406c77f4e828045/psutil-7.2.2-cp36-abi3-manylinux2010_x86_64.manylinux_2_12_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:076a2d2f923fd4821644f5ba89f059523da90dc9014e85f8e45a5774ca5bc6f9", size = 155560, upload-time = "2026-01-28T18:15:25.976Z" },
+    { url = "https://files.pythonhosted.org/packages/63/65/37648c0c158dc222aba51c089eb3bdfa238e621674dc42d48706e639204f/psutil-7.2.2-cp36-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b0726cecd84f9474419d67252add4ac0cd9811b04d61123054b9fb6f57df6e9e", size = 156997, upload-time = "2026-01-28T18:15:27.794Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/13/125093eadae863ce03c6ffdbae9929430d116a246ef69866dad94da3bfbc/psutil-7.2.2-cp36-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:fd04ef36b4a6d599bbdb225dd1d3f51e00105f6d48a28f006da7f9822f2606d8", size = 148972, upload-time = "2026-01-28T18:15:29.342Z" },
+    { url = "https://files.pythonhosted.org/packages/04/78/0acd37ca84ce3ddffaa92ef0f571e073faa6d8ff1f0559ab1272188ea2be/psutil-7.2.2-cp36-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:b58fabe35e80b264a4e3bb23e6b96f9e45a3df7fb7eed419ac0e5947c61e47cc", size = 148266, upload-time = "2026-01-28T18:15:31.597Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/90/e2159492b5426be0c1fef7acba807a03511f97c5f86b3caeda6ad92351a7/psutil-7.2.2-cp37-abi3-win_amd64.whl", hash = "sha256:eb7e81434c8d223ec4a219b5fc1c47d0417b12be7ea866e24fb5ad6e84b3d988", size = 137737, upload-time = "2026-01-28T18:15:33.849Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/c7/7bb2e321574b10df20cbde462a94e2b71d05f9bbda251ef27d104668306a/psutil-7.2.2-cp37-abi3-win_arm64.whl", hash = "sha256:8c233660f575a5a89e6d4cb65d9f938126312bca76d8fe087b947b3a1aaac9ee", size = 134617, upload-time = "2026-01-28T18:15:36.514Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

`psutil` was only available as a dev typing stub (`types-psutil`), not as a runtime dependency. `ResourceMonitor` soft-imported it and fell back to hardcoded estimates (50% CPU, 50% memory, 50 GB disk) when missing. That meant resource-aware throttling in `ParallelExecutionManager._dispatch_loop()` never paused under real resource pressure for standard installs.

This PR adds `psutil>=5.9.0` as a runtime dependency so parallel dispatch uses real system metrics. The graceful `ImportError` fallback and warning path are preserved for edge cases where `psutil` is unavailable.

## Changes

- Add `psutil>=5.9.0` to `[project] dependencies` in `cli/pyproject.toml`
- Regenerate `cli/uv.lock`
- Update fallback warning in `ResourceMonitor._try_import_psutil()` to suggest reinstalling localci instead of `pip install psutil`
- Add `cli/tests/test_resources.py` with dedicated `ResourceMonitor` coverage
- Remove duplicated `TestResourceMonitor` from `cli/tests/test_orchestrator.py`

## Acceptance criteria

- [x] `psutil` added to `[project] dependencies` with version constraint
- [x] `_try_import_psutil()` still handles `ImportError` gracefully
- [x] Fallback path emits `logging.warning()`
- [x] Unit test verifies `snapshot()` returns real values when psutil is importable
- [x] Unit test verifies fallback path when psutil import raises `ImportError`

## Test plan

- [x] `pytest tests/test_resources.py -v`
- [x] `pytest tests/ -v` (full suite)
- [x] `ruff check localci/ tests/`

## Follow-up (out of scope)

- Remove the `ignore_errors` mypy override for `localci.utils.resources` once the module is fully typed (`types-psutil` is already in dev deps)

## Related issue
- Close https://github.com/cppalliance/local-ci-test-system/issues/64

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added `psutil` as an explicit dependency to keep resource monitoring consistent.
* **Bug Fixes**
  * Improved the warning shown when resource monitoring dependencies can’t be loaded, including clearer restore instructions.
* **Tests**
  * Added dedicated coverage for `ResourceMonitor` snapshot and threshold behavior, including fallback behavior when `psutil` is unavailable.
  * Updated parallel execution status checks to assert non-idle status and the presence of `total_jobs` and `resources` fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->