### PR TITLE
Log warnings on silent patch step skips

### DIFF
--- a/cli/localci/core/patch_pipeline.py
+++ b/cli/localci/core/patch_pipeline.py
@@ -25,7 +25,11 @@ class PatchStep(ABC):
 
     @abstractmethod
     def apply(self, ctx: PatchContext) -> None:
-        """Apply this patch in place to ``ctx.lines``."""
+        """Apply this patch in place to ``ctx.lines``.
+
+        Early exits that do not modify ``ctx.lines`` must call
+        :meth:`_skip` with an actionable reason.
+        """
 
     def _skip(self, reason: str) -> None:
         """Log a warning when this step exits without modifying the workflow."""

--- a/cli/localci/core/patch_pipeline.py
+++ b/cli/localci/core/patch_pipeline.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 from localci.core.config import PATCH_STEP_NAMES, LocalCIConfig
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from localci.core.workflow import MatrixEntry
@@ -23,6 +26,10 @@ class PatchStep(ABC):
     @abstractmethod
     def apply(self, ctx: PatchContext) -> None:
         """Apply this patch in place to ``ctx.lines``."""
+
+    def _skip(self, reason: str) -> None:
+        """Log a warning when this step exits without modifying the workflow."""
+        logger.warning("Patch step %r skipped: %s", self.name, reason)
 
 
 @dataclass

--- a/cli/localci/core/patch_pipeline.py
+++ b/cli/localci/core/patch_pipeline.py
@@ -29,7 +29,7 @@ class PatchStep(ABC):
 
     def _skip(self, reason: str) -> None:
         """Log a warning when this step exits without modifying the workflow."""
-        logger.warning("Patch step %r skipped: %s", self.name, reason)
+        logger.warning("Patch step %s skipped: %s", self.name, reason)
 
 
 @dataclass

--- a/cli/localci/core/patch_steps.py
+++ b/cli/localci/core/patch_steps.py
@@ -41,7 +41,7 @@ class ContainerMountsStep(PatchStep):
 
     def apply(self, ctx: PatchContext) -> None:
         if not ctx.job_id or not ctx.container_mount_options:
-            return
+            return self._skip("job_id and container_mount_options are required")
         job_header = re.compile(r"^\s{2}" + re.escape(ctx.job_id) + r"\s*:\s*$")
         for i, line in enumerate(ctx.lines):
             if not job_header.match(line):
@@ -69,8 +69,10 @@ class ContainerMountsStep(PatchStep):
                             j + 1,
                             f'{options_indent}options: "{ctx.container_mount_options}"\n',
                         )
-                    break
-            break
+                    return
+            self._skip(f"job {ctx.job_id!r} has no container block")
+            return
+        self._skip(f"job {ctx.job_id!r} not found in workflow")
 
 
 class B2SourceCacheStep(PatchStep):
@@ -100,7 +102,8 @@ class B2SourceCacheStep(PatchStep):
                     f"{ind}  fi\n"
                     f"{ind}fi\n"
                 )
-                break
+                return
+        self._skip("no cp -rL boost-source boost-root line found")
 
 
 class RestoreCapyTimestampsStep(PatchStep):
@@ -118,24 +121,27 @@ class RestoreCapyTimestampsStep(PatchStep):
             already_patched = any(
                 "capy-file-stats" in ctx.lines[j] for j in range(max(0, i - 15), i)
             )
-            if not already_patched:
-                list_indent = step_match.group(1)
-                prop_indent = list_indent + "  "
-                body_indent = prop_indent + "  "
-                new_step = [
-                    f"{list_indent}- name: Restore capy source file timestamps\n",
-                    f"{prop_indent}run: |\n",
-                    f'{body_indent}if [ -n "${{LOCALCI_B2_SOURCE_DIR:-}}" ] && [ -f "${{LOCALCI_B2_SOURCE_DIR}}/.capy-file-stats" ]; then\n',
-                    f"{body_indent}  while IFS=' ' read -r saved_mtime fhash relpath; do\n",
-                    f'{body_indent}    [ -f "capy-root/$relpath" ] || continue\n',
-                    f"{body_indent}    curr=$(sha256sum \"capy-root/$relpath\" 2>/dev/null | cut -d' ' -f1)\n",
-                    f'{body_indent}    [ "$curr" = "$fhash" ] && touch -d "@$saved_mtime" "capy-root/$relpath" 2>/dev/null || true\n',
-                    f'{body_indent}  done < "${{LOCALCI_B2_SOURCE_DIR}}/.capy-file-stats"\n',
-                    f"{body_indent}fi\n",
-                ]
-                for j, new_line in enumerate(new_step):
-                    ctx.lines.insert(i + j, new_line)
-            break
+            if already_patched:
+                self._skip("restore step already present")
+                return
+            list_indent = step_match.group(1)
+            prop_indent = list_indent + "  "
+            body_indent = prop_indent + "  "
+            new_step = [
+                f"{list_indent}- name: Restore capy source file timestamps\n",
+                f"{prop_indent}run: |\n",
+                f'{body_indent}if [ -n "${{LOCALCI_B2_SOURCE_DIR:-}}" ] && [ -f "${{LOCALCI_B2_SOURCE_DIR}}/.capy-file-stats" ]; then\n',
+                f"{body_indent}  while IFS=' ' read -r saved_mtime fhash relpath; do\n",
+                f'{body_indent}    [ -f "capy-root/$relpath" ] || continue\n',
+                f"{body_indent}    curr=$(sha256sum \"capy-root/$relpath\" 2>/dev/null | cut -d' ' -f1)\n",
+                f'{body_indent}    [ "$curr" = "$fhash" ] && touch -d "@$saved_mtime" "capy-root/$relpath" 2>/dev/null || true\n',
+                f'{body_indent}  done < "${{LOCALCI_B2_SOURCE_DIR}}/.capy-file-stats"\n',
+                f"{body_indent}fi\n",
+            ]
+            for j, new_line in enumerate(new_step):
+                ctx.lines.insert(i + j, new_line)
+            return
+        self._skip("Patch Boost step not found")
 
 
 class CapyCopyPreservationStep(PatchStep):
@@ -161,7 +167,8 @@ class CapyCopyPreservationStep(PatchStep):
                     f'{ind}  done > "${{LOCALCI_B2_SOURCE_DIR}}/.capy-file-stats"\n'
                     f"{ind}fi\n"
                 )
-                break
+                return
+        self._skip('no cp -r "$workspace_root" capy copy line found')
 
 
 class B2BootstrapSkipStep(PatchStep):
@@ -183,21 +190,24 @@ class B2BootstrapSkipStep(PatchStep):
                     "Skip b2 bootstrap" in ctx.lines[j]
                     for j in range(max(0, step_start - 15), step_start)
                 )
-                if not already_patched:
-                    list_indent, prop_indent, body_indent = _step_insert_indents(
-                        ctx.lines, step_start
-                    )
-                    new_step = [
-                        f"{list_indent}- name: Skip b2 bootstrap (b2 binary cached)\n",
-                        f"{prop_indent}run: |\n",
-                        f'{body_indent}if [ -n "${{LOCALCI_B2_SOURCE_DIR:-}}" ] && [ -f "${{LOCALCI_B2_SOURCE_DIR}}/b2" ]; then\n',
-                        f"{body_indent}  printf '#!/bin/sh\\necho \"b2 binary cached, skipping bootstrap.\"\\n' > boost-root/bootstrap.sh\n",
-                        f"{body_indent}  chmod +x boost-root/bootstrap.sh\n",
-                        f"{body_indent}fi\n",
-                    ]
-                    for j, new_line in enumerate(new_step):
-                        ctx.lines.insert(step_start + j, new_line)
-                break
+                if already_patched:
+                    self._skip("skip b2 bootstrap step already present")
+                    return
+                list_indent, prop_indent, body_indent = _step_insert_indents(
+                    ctx.lines, step_start
+                )
+                new_step = [
+                    f"{list_indent}- name: Skip b2 bootstrap (b2 binary cached)\n",
+                    f"{prop_indent}run: |\n",
+                    f'{body_indent}if [ -n "${{LOCALCI_B2_SOURCE_DIR:-}}" ] && [ -f "${{LOCALCI_B2_SOURCE_DIR}}/b2" ]; then\n',
+                    f"{body_indent}  printf '#!/bin/sh\\necho \"b2 binary cached, skipping bootstrap.\"\\n' > boost-root/bootstrap.sh\n",
+                    f"{body_indent}  chmod +x boost-root/bootstrap.sh\n",
+                    f"{body_indent}fi\n",
+                ]
+                for j, new_line in enumerate(new_step):
+                    ctx.lines.insert(step_start + j, new_line)
+                return
+        self._skip("no b2-workflow uses step found")
 
 
 class ImageSubstitutionStep(PatchStep):
@@ -209,7 +219,7 @@ class ImageSubstitutionStep(PatchStep):
 
     def apply(self, ctx: PatchContext) -> None:
         if not ctx.image_tag:
-            return
+            return self._skip("image_tag not provided")
         name_escaped = re.escape(ctx.entry.name)
         name_pattern = re.compile(r'name:\s*["\']?' + name_escaped + r'["\']?\s*$')
         name_idx = None
@@ -255,7 +265,8 @@ class ImageSubstitutionStep(PatchStep):
             mo = container_pattern.match(ctx.lines[i])
             if mo:
                 ctx.lines[i] = f'{mo.group(1)}container: "{ctx.image_tag}"\n'
-                break
+                return
+        self._skip("container field not found in matrix entry block")
 
 
 class CodecovSkipStep(PatchStep):
@@ -280,7 +291,8 @@ class CodecovSkipStep(PatchStep):
                         f"{indent}{act_check}{rest}; "
                         f'else echo "Skipping Codecov upload (running under act)."; fi\n'
                     )
-                break
+                    return
+        self._skip("no Codecov upload step found")
 
 
 PATCH_STEP_REGISTRY: dict[str, type[PatchStep]] = {

--- a/cli/localci/core/patch_steps.py
+++ b/cli/localci/core/patch_steps.py
@@ -41,7 +41,8 @@ class ContainerMountsStep(PatchStep):
 
     def apply(self, ctx: PatchContext) -> None:
         if not ctx.job_id or not ctx.container_mount_options:
-            return self._skip("job_id and container_mount_options are required")
+            self._skip("job_id and container_mount_options are required")
+            return
         job_header = re.compile(r"^\s{2}" + re.escape(ctx.job_id) + r"\s*:\s*$")
         for i, line in enumerate(ctx.lines):
             if not job_header.match(line):
@@ -73,6 +74,7 @@ class ContainerMountsStep(PatchStep):
             self._skip(f"job {ctx.job_id!r} has no container block")
             return
         self._skip(f"job {ctx.job_id!r} not found in workflow")
+        return
 
 
 class B2SourceCacheStep(PatchStep):
@@ -104,6 +106,7 @@ class B2SourceCacheStep(PatchStep):
                 )
                 return
         self._skip("no cp -rL boost-source boost-root line found")
+        return
 
 
 class RestoreCapyTimestampsStep(PatchStep):
@@ -142,6 +145,7 @@ class RestoreCapyTimestampsStep(PatchStep):
                 ctx.lines.insert(i + j, new_line)
             return
         self._skip("Patch Boost step not found")
+        return
 
 
 class CapyCopyPreservationStep(PatchStep):
@@ -169,6 +173,7 @@ class CapyCopyPreservationStep(PatchStep):
                 )
                 return
         self._skip('no cp -r "$workspace_root" capy copy line found')
+        return
 
 
 class B2BootstrapSkipStep(PatchStep):
@@ -208,10 +213,16 @@ class B2BootstrapSkipStep(PatchStep):
                     ctx.lines.insert(step_start + j, new_line)
                 return
         self._skip("no b2-workflow uses step found")
+        return
 
 
 class ImageSubstitutionStep(PatchStep):
-    """Replace matrix container image with the locally-built image tag."""
+    """Replace matrix container image with the locally-built image tag.
+
+    Raises ValueError if the matrix entry name is not found (unexpected workflow
+    structure). Skips with a warning if the container field is absent from the
+    entry block (valid but unsupported layout).
+    """
 
     @property
     def name(self) -> str:
@@ -219,7 +230,8 @@ class ImageSubstitutionStep(PatchStep):
 
     def apply(self, ctx: PatchContext) -> None:
         if not ctx.image_tag:
-            return self._skip("image_tag not provided")
+            self._skip("image_tag not provided")
+            return
         name_escaped = re.escape(ctx.entry.name)
         name_pattern = re.compile(r'name:\s*["\']?' + name_escaped + r'["\']?\s*$')
         name_idx = None
@@ -267,6 +279,7 @@ class ImageSubstitutionStep(PatchStep):
                 ctx.lines[i] = f'{mo.group(1)}container: "{ctx.image_tag}"\n'
                 return
         self._skip("container field not found in matrix entry block")
+        return
 
 
 class CodecovSkipStep(PatchStep):
@@ -293,6 +306,7 @@ class CodecovSkipStep(PatchStep):
                     )
                     return
         self._skip("no Codecov upload step found")
+        return
 
 
 PATCH_STEP_REGISTRY: dict[str, type[PatchStep]] = {

--- a/cli/tests/fixtures/patcher/container_image_no_container.yml
+++ b/cli/tests/fixtures/patcher/container_image_no_container.yml
@@ -1,0 +1,13 @@
+name: Container Image No Container Field
+on:
+  push:
+jobs:
+  build:
+    strategy:
+      matrix:
+        include:
+          - name: "GCC 15: C++20"
+            runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - run: echo build

--- a/cli/tests/fixtures/patcher/container_mount_no_container_block.yml
+++ b/cli/tests/fixtures/patcher/container_mount_no_container_block.yml
@@ -1,0 +1,8 @@
+name: Container Mount No Container Block
+on:
+  push:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo build

--- a/cli/tests/test_patch_pipeline.py
+++ b/cli/tests/test_patch_pipeline.py
@@ -209,7 +209,8 @@ def test_patch_step_skip_emits_warning(sample_entry: MatrixEntry, caplog) -> Non
         ContainerMountsStep().apply(ctx)
 
     assert any(
-        "container_mounts" in r.message
+        r.levelno == logging.WARNING
+        and "container_mounts" in r.message
         and "job_id and container_mount_options are required" in r.message
         for r in caplog.records
     )

--- a/cli/tests/test_patch_pipeline.py
+++ b/cli/tests/test_patch_pipeline.py
@@ -2,13 +2,15 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
 
 from localci.cli.run.patcher import _write_patched_workflow
 from localci.core.config import LocalCIConfig, PatchesConfig
-from localci.core.patch_pipeline import PatchPipeline
+from localci.core.patch_pipeline import PatchContext, PatchPipeline
+from localci.core.patch_steps import ContainerMountsStep
 from localci.core.workflow import (
     BuildSystem,
     BuildVariant,
@@ -192,3 +194,22 @@ def test_patches_config_rejects_enabled_step_missing_from_order() -> None:
                 "image_substitution",
             ],
         )
+
+
+def test_patch_step_skip_emits_warning(sample_entry: MatrixEntry, caplog) -> None:
+    """Enabled patch step with incomplete context logs a skip warning."""
+    ctx = PatchContext(
+        lines=["jobs:\n", "  build:\n", "    runs-on: ubuntu-latest\n"],
+        entry=sample_entry,
+        config=LocalCIConfig(),
+        job_id=None,
+        container_mount_options=None,
+    )
+    with caplog.at_level(logging.WARNING, logger="localci.core.patch_pipeline"):
+        ContainerMountsStep().apply(ctx)
+
+    assert any(
+        "container_mounts" in r.message
+        and "job_id and container_mount_options are required" in r.message
+        for r in caplog.records
+    )

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -54,6 +54,34 @@ def _container_mounts_only_config() -> LocalCIConfig:
     )
 
 
+def _restore_capy_only_config() -> LocalCIConfig:
+    return LocalCIConfig(
+        patches=PatchesConfig(
+            container_mounts=False,
+            b2_source_cache=False,
+            restore_capy_timestamps=True,
+            capy_copy_preservation=False,
+            b2_bootstrap_skip=False,
+            image_substitution=False,
+            codecov_skip=False,
+        )
+    )
+
+
+def _image_substitution_only_config() -> LocalCIConfig:
+    return LocalCIConfig(
+        patches=PatchesConfig(
+            container_mounts=False,
+            b2_source_cache=False,
+            restore_capy_timestamps=False,
+            capy_copy_preservation=False,
+            b2_bootstrap_skip=False,
+            image_substitution=True,
+            codecov_skip=False,
+        )
+    )
+
+
 def _make_entry(name: str = "GCC 15: C++20") -> MatrixEntry:
     return MatrixEntry(
         index=0,
@@ -141,6 +169,25 @@ class TestContainerImagePatch:
         assert 'container: "ubuntu:25.04"' in content
         assert "localci/" not in content
         _assert_skip_warning(caplog, "image_substitution", "image_tag not provided")
+
+    def test_negative_skips_when_matrix_entry_has_no_container_field(
+        self, patcher_paths, caplog
+    ):
+        workflow = FIXTURES_DIR / "container_image_no_container.yml"
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(
+                workflow,
+                _make_entry("GCC 15: C++20"),
+                image_tag="localci/gcc-15:custom",
+                config=_image_substitution_only_config(),
+            )
+        content = _assert_valid_yaml(patched)
+        assert "localci/gcc-15:custom" not in content
+        _assert_skip_warning(
+            caplog,
+            "image_substitution",
+            "container field not found in matrix entry block",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -296,6 +343,18 @@ class TestCapyTimestampsPatch:
         assert content.count("Restore capy source file timestamps") == 1
         _assert_skip_warning(
             caplog, "restore_capy_timestamps", "restore step already present"
+        )
+
+    def test_negative_skips_when_patch_boost_step_absent(
+        self, patcher_paths, caplog
+    ):
+        workflow = FIXTURES_DIR / "container_image.yml"
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow, config=_restore_capy_only_config())
+        content = _assert_valid_yaml(patched)
+        assert "Restore capy source file timestamps" not in content
+        _assert_skip_warning(
+            caplog, "restore_capy_timestamps", "Patch Boost step not found"
         )
 
 

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -12,6 +12,7 @@ import pytest
 import yaml
 
 from localci.cli.run import _write_patched_workflow
+from localci.core.config import LocalCIConfig, PatchesConfig
 from localci.core.workflow import (
     BuildSystem,
     BuildVariant,
@@ -29,10 +30,27 @@ PATCH_LOGGER = "localci.core.patch_pipeline"
 
 def _assert_skip_warning(caplog, step_name: str, reason_fragment: str) -> None:
     assert any(
-        step_name in r.message and reason_fragment in r.message for r in caplog.records
+        r.levelno == logging.WARNING
+        and step_name in r.message
+        and reason_fragment in r.message
+        for r in caplog.records
     ), (
-        f"expected skip warning for {step_name!r} containing {reason_fragment!r}, "
-        f"got: {[r.message for r in caplog.records]}"
+        f"expected WARNING for {step_name!r} containing {reason_fragment!r}, "
+        f"got: {[(r.levelname, r.message) for r in caplog.records]}"
+    )
+
+
+def _container_mounts_only_config() -> LocalCIConfig:
+    return LocalCIConfig(
+        patches=PatchesConfig(
+            container_mounts=True,
+            b2_source_cache=False,
+            restore_capy_timestamps=False,
+            capy_copy_preservation=False,
+            b2_bootstrap_skip=False,
+            image_substitution=False,
+            codecov_skip=False,
+        )
     )
 
 
@@ -184,6 +202,40 @@ class TestContainerMountPatch:
             "job_id and container_mount_options are required",
         )
 
+    def test_negative_skips_when_job_has_no_container_block(
+        self, patcher_paths, caplog
+    ):
+        workflow = FIXTURES_DIR / "container_mount_no_container_block.yml"
+        original = workflow.read_text(encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(
+                workflow,
+                job_id="build",
+                container_mount_options="-v /host/boost:/cache",
+                config=_container_mounts_only_config(),
+            )
+        content = _assert_valid_yaml(patched)
+        assert content == original.replace("\r\n", "\n")
+        _assert_skip_warning(
+            caplog, "container_mounts", "job 'build' has no container block"
+        )
+
+    def test_negative_skips_when_job_not_found(self, patcher_paths, caplog):
+        workflow = FIXTURES_DIR / "container_mount.yml"
+        original = workflow.read_text(encoding="utf-8")
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(
+                workflow,
+                job_id="missing_job",
+                container_mount_options="-v /host/boost:/cache",
+                config=_container_mounts_only_config(),
+            )
+        content = _assert_valid_yaml(patched)
+        assert content == original.replace("\r\n", "\n")
+        _assert_skip_warning(
+            caplog, "container_mounts", "job 'missing_job' not found in workflow"
+        )
+
 
 # ---------------------------------------------------------------------------
 # boost-source cache (cp -rL replacement)
@@ -266,6 +318,8 @@ class TestCapyCopyPatch:
     def test_negative_no_cp_rp_injected_when_capy_copy_line_absent(
         self, patcher_paths, caplog
     ):
+        # Full default pipeline on boost_cache.yml skips several steps; we assert
+        # only the capy_copy_preservation warning for this fixture.
         workflow = FIXTURES_DIR / "boost_cache.yml"
         with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
             patched = patcher_paths(workflow)

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -5,6 +5,7 @@ Each patch type has positive and negative cases using minimal YAML fixtures.
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 
 import pytest
@@ -23,6 +24,16 @@ from localci.core.workflow import (
 )
 
 FIXTURES_DIR = Path(__file__).parent / "fixtures" / "patcher"
+PATCH_LOGGER = "localci.core.patch_pipeline"
+
+
+def _assert_skip_warning(caplog, step_name: str, reason_fragment: str) -> None:
+    assert any(
+        step_name in r.message and reason_fragment in r.message for r in caplog.records
+    ), (
+        f"expected skip warning for {step_name!r} containing {reason_fragment!r}, "
+        f"got: {[r.message for r in caplog.records]}"
+    )
 
 
 def _make_entry(name: str = "GCC 15: C++20") -> MatrixEntry:
@@ -104,12 +115,14 @@ class TestContainerImagePatch:
                 image_tag="localci/missing:latest",
             )
 
-    def test_negative_skips_when_image_tag_not_provided(self, patcher_paths):
+    def test_negative_skips_when_image_tag_not_provided(self, patcher_paths, caplog):
         workflow = FIXTURES_DIR / "container_image.yml"
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert 'container: "ubuntu:25.04"' in content
         assert "localci/" not in content
+        _assert_skip_warning(caplog, "image_substitution", "image_tag not provided")
 
 
 # ---------------------------------------------------------------------------
@@ -142,22 +155,34 @@ class TestContainerMountPatch:
         if has_existing_options:
             assert "--privileged" in content
 
-    def test_negative_skips_without_job_id(self, patcher_paths):
+    def test_negative_skips_without_job_id(self, patcher_paths, caplog):
         workflow = FIXTURES_DIR / "container_mount.yml"
         original = workflow.read_text(encoding="utf-8")
-        patched = patcher_paths(
-            workflow,
-            container_mount_options="-v /host/boost:/cache",
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(
+                workflow,
+                container_mount_options="-v /host/boost:/cache",
+            )
+        content = _assert_valid_yaml(patched)
+        assert content == original.replace("\r\n", "\n")
+        _assert_skip_warning(
+            caplog,
+            "container_mounts",
+            "job_id and container_mount_options are required",
         )
-        content = _assert_valid_yaml(patched)
-        assert content == original.replace("\r\n", "\n")
 
-    def test_negative_skips_without_mount_options(self, patcher_paths):
+    def test_negative_skips_without_mount_options(self, patcher_paths, caplog):
         workflow = FIXTURES_DIR / "container_mount.yml"
         original = workflow.read_text(encoding="utf-8")
-        patched = patcher_paths(workflow, job_id="build")
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow, job_id="build")
         content = _assert_valid_yaml(patched)
         assert content == original.replace("\r\n", "\n")
+        _assert_skip_warning(
+            caplog,
+            "container_mounts",
+            "job_id and container_mount_options are required",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -177,15 +202,19 @@ class TestBoostCachePatch:
         assert "cp -a boost-root/." in content
 
     def test_negative_leaves_workflow_unchanged_without_boost_copy_line(
-        self, patcher_paths
+        self, patcher_paths, caplog
     ):
         workflow = FIXTURES_DIR / "container_image.yml"
         original = workflow.read_text(encoding="utf-8")
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert "LOCALCI_B2_SOURCE_DIR" not in content
         assert "cp -rL boost-source boost-root" not in content
         assert content == original.replace("\r\n", "\n")
+        _assert_skip_warning(
+            caplog, "b2_source_cache", "no cp -rL boost-source boost-root line found"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -205,11 +234,17 @@ class TestCapyTimestampsPatch:
             "Patch Boost"
         )
 
-    def test_negative_skips_duplicate_on_already_patched_workflow(self, patcher_paths):
+    def test_negative_skips_duplicate_on_already_patched_workflow(
+        self, patcher_paths, caplog
+    ):
         workflow = FIXTURES_DIR / "already_patched.yml"
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert content.count("Restore capy source file timestamps") == 1
+        _assert_skip_warning(
+            caplog, "restore_capy_timestamps", "restore step already present"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -228,11 +263,19 @@ class TestCapyCopyPatch:
         assert "sha256sum" in content
         assert 'cp -r "$workspace_root"' not in content
 
-    def test_negative_no_cp_rp_injected_when_capy_copy_line_absent(self, patcher_paths):
+    def test_negative_no_cp_rp_injected_when_capy_copy_line_absent(
+        self, patcher_paths, caplog
+    ):
         workflow = FIXTURES_DIR / "boost_cache.yml"
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert 'cp -rp "$workspace_root"' not in content
+        _assert_skip_warning(
+            caplog,
+            "capy_copy_preservation",
+            'no cp -r "$workspace_root" capy copy line found',
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -250,11 +293,15 @@ class TestB2BootstrapPatch:
         assert "bootstrap.sh" in content
         assert content.index("Skip b2 bootstrap") < content.index("b2-workflow")
 
-    def test_negative_skips_when_b2_workflow_step_absent(self, patcher_paths):
+    def test_negative_skips_when_b2_workflow_step_absent(self, patcher_paths, caplog):
         workflow = FIXTURES_DIR / "boost_cache.yml"
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert "Skip b2 bootstrap (b2 binary cached)" not in content
+        _assert_skip_warning(
+            caplog, "b2_bootstrap_skip", "no b2-workflow uses step found"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -272,13 +319,17 @@ class TestCodecovPatch:
         assert "Skipping Codecov upload (running under act)" in content
         assert "https://codecov.io/bash" in content
 
-    def test_negative_leaves_workflow_without_codecov_unchanged(self, patcher_paths):
+    def test_negative_leaves_workflow_without_codecov_unchanged(
+        self, patcher_paths, caplog
+    ):
         workflow = FIXTURES_DIR / "boost_cache.yml"
-        patched = patcher_paths(workflow)
+        with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
+            patched = patcher_paths(workflow)
         content = _assert_valid_yaml(patched)
         assert "codecov.io" not in content
         assert "ACT" not in content
         assert "LOCALCI_B2_SOURCE_DIR" in content
+        _assert_skip_warning(caplog, "codecov_skip", "no Codecov upload step found")
 
 
 # ---------------------------------------------------------------------------

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -345,9 +345,7 @@ class TestCapyTimestampsPatch:
             caplog, "restore_capy_timestamps", "restore step already present"
         )
 
-    def test_negative_skips_when_patch_boost_step_absent(
-        self, patcher_paths, caplog
-    ):
+    def test_negative_skips_when_patch_boost_step_absent(self, patcher_paths, caplog):
         workflow = FIXTURES_DIR / "container_image.yml"
         with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
             patched = patcher_paths(workflow, config=_restore_capy_only_config())

--- a/cli/tests/test_patcher_patches.py
+++ b/cli/tests/test_patcher_patches.py
@@ -82,6 +82,20 @@ def _image_substitution_only_config() -> LocalCIConfig:
     )
 
 
+def _b2_source_cache_only_config() -> LocalCIConfig:
+    return LocalCIConfig(
+        patches=PatchesConfig(
+            container_mounts=False,
+            b2_source_cache=True,
+            restore_capy_timestamps=False,
+            capy_copy_preservation=False,
+            b2_bootstrap_skip=False,
+            image_substitution=False,
+            codecov_skip=False,
+        )
+    )
+
+
 def _make_entry(name: str = "GCC 15: C++20") -> MatrixEntry:
     return MatrixEntry(
         index=0,
@@ -306,7 +320,7 @@ class TestBoostCachePatch:
         workflow = FIXTURES_DIR / "container_image.yml"
         original = workflow.read_text(encoding="utf-8")
         with caplog.at_level(logging.WARNING, logger=PATCH_LOGGER):
-            patched = patcher_paths(workflow)
+            patched = patcher_paths(workflow, config=_b2_source_cache_only_config())
         content = _assert_valid_yaml(patched)
         assert "LOCALCI_B2_SOURCE_DIR" not in content
         assert "cp -rL boost-source boost-root" not in content


### PR DESCRIPTION
## Summary

- Add `PatchStep._skip(reason)` on the patch pipeline base class to emit `logging.warning` with the step name and skip reason.
- Instrument all seven patch steps (`container_mounts`, `b2_source_cache`, `restore_capy_timestamps`, `capy_copy_preservation`, `b2_bootstrap_skip`, `image_substitution`, `codecov_skip`) on every no-op exit path.
- Extend eight existing negative tests in `test_patcher_patches.py` and add `test_patch_step_skip_emits_warning` in `test_patch_pipeline.py`.

Patch steps that returned without changing workflow YAML gave no diagnostic when config was incomplete or target content was missing.

## Test plan

- [x] `pytest tests/test_patch_pipeline.py tests/test_patcher_patches.py`
- [x] `pytest -m "not integration"`
- [x] `ruff check` / `ruff format --check` / `mypy localci/core/patch_pipeline.py localci/core/patch_steps.py`

## Related issue

- Close https://github.com/cppalliance/local-ci-test-system/issues/65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the patching flow to safely and consistently skip unsupported scenarios (or when changes are already present) using actionable warning logs, without modifying workflow contents unexpectedly.
* **Tests**
  * Expanded negative/skip coverage across container mounts, boost source cache, Capy timestamps/copy preservation, B2 bootstrap skip, image substitution, and Codecov.
  * Added log assertions to verify the correct step name and skip reason, plus new workflow fixtures for missing container-related fields.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->