### PR TITLE
test: matrix precedence + event-file ownership guard (#82)

### DIFF
--- a/cli/localci/core/command_builder.py
+++ b/cli/localci/core/command_builder.py
@@ -201,7 +201,7 @@ class ActCommandBuilder:
         # Event file
         event_file = self._create_event_file()
 
-        return ActCommand(
+        cmd = ActCommand(
             workflow_file=wf_path,
             job_id=self.job_id,
             matrix_filters=matrix_filters,
@@ -221,6 +221,8 @@ class ActCommandBuilder:
             workdir=self.project_dir,
             act_version=self.act_version,
         )
+        cmd._executor_owned_event_file = True
+        return cmd
 
     # -----------------------------------------------------------------
     # Matrix filters

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -207,7 +207,7 @@ class ActCommand:
 
     # Event
     event_file: Path | None = None
-    _executor_owned_event_file: bool = field(default=False, repr=False)
+    _executor_owned_event_file: bool = field(default=False, init=False, repr=False)
 
     # Container
     container_architecture: str | None = None

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -161,11 +161,14 @@ class ActCommand:
       caller file is left on disk.
     * :attr:`secret_file` and :attr:`_executor_owned_secret_file` are set when
       :attr:`secrets` is non-empty (a ``0600`` temp file is created).
+    * :attr:`event_file` and :attr:`_executor_owned_event_file` are set when
+      :class:`~localci.core.command_builder.ActCommandBuilder` creates the
+      default event payload temp file.
 
     The ownership flags tell :meth:`JobExecutor._cleanup_temp_files` (called from
     :meth:`JobExecutor.run`'s ``finally`` block) which temp files the executor
-    created and must delete. Caller-provided ``env_file`` / ``secret_file`` paths
-    without the ownership flag are left on disk.
+    created and must delete. Caller-provided ``env_file`` / ``secret_file`` /
+    ``event_file`` paths without the ownership flag are left on disk.
 
     **Single-use per execution.** Build a fresh :class:`ActCommand` for each
     call to :meth:`JobExecutor.run`. Reusing the same instance across runs is
@@ -202,6 +205,7 @@ class ActCommand:
     secret_file: Path | None = None
     _executor_owned_env_file: bool = field(default=False, repr=False)
     _executor_owned_secret_file: bool = field(default=False, repr=False)
+    _executor_owned_event_file: bool = field(default=False, repr=False)
 
     # Event
     event_file: Path | None = None
@@ -775,7 +779,12 @@ class JobExecutor:
     @staticmethod
     def _cleanup_temp_files(cmd: ActCommand | None) -> None:
         """Remove temporary files created during execution."""
-        if cmd and cmd.event_file and cmd.event_file.exists():
+        if (
+            cmd
+            and cmd._executor_owned_event_file
+            and cmd.event_file
+            and cmd.event_file.exists()
+        ):
             with suppress(OSError):
                 cmd.event_file.unlink()
         if (

--- a/cli/localci/core/executor.py
+++ b/cli/localci/core/executor.py
@@ -161,9 +161,8 @@ class ActCommand:
       caller file is left on disk.
     * :attr:`secret_file` and :attr:`_executor_owned_secret_file` are set when
       :attr:`secrets` is non-empty (a ``0600`` temp file is created).
-    * :attr:`event_file` and :attr:`_executor_owned_event_file` are set when
-      :class:`~localci.core.command_builder.ActCommandBuilder` creates the
-      default event payload temp file.
+    * :attr:`event_file` and :attr:`_executor_owned_event_file` are set by
+      :class:`~localci.core.command_builder.ActCommandBuilder`.
 
     The ownership flags tell :meth:`JobExecutor._cleanup_temp_files` (called from
     :meth:`JobExecutor.run`'s ``finally`` block) which temp files the executor
@@ -205,10 +204,10 @@ class ActCommand:
     secret_file: Path | None = None
     _executor_owned_env_file: bool = field(default=False, repr=False)
     _executor_owned_secret_file: bool = field(default=False, repr=False)
-    _executor_owned_event_file: bool = field(default=False, repr=False)
 
     # Event
     event_file: Path | None = None
+    _executor_owned_event_file: bool = field(default=False, repr=False)
 
     # Container
     container_architecture: str | None = None
@@ -779,27 +778,13 @@ class JobExecutor:
     @staticmethod
     def _cleanup_temp_files(cmd: ActCommand | None) -> None:
         """Remove temporary files created during execution."""
-        if (
-            cmd
-            and cmd._executor_owned_event_file
-            and cmd.event_file
-            and cmd.event_file.exists()
+        if not cmd:
+            return
+        for owned, path in (
+            (cmd._executor_owned_event_file, cmd.event_file),
+            (cmd._executor_owned_env_file, cmd.env_file),
+            (cmd._executor_owned_secret_file, cmd.secret_file),
         ):
-            with suppress(OSError):
-                cmd.event_file.unlink()
-        if (
-            cmd
-            and cmd._executor_owned_env_file
-            and cmd.env_file
-            and cmd.env_file.exists()
-        ):
-            with suppress(OSError):
-                cmd.env_file.unlink()
-        if (
-            cmd
-            and cmd._executor_owned_secret_file
-            and cmd.secret_file
-            and cmd.secret_file.exists()
-        ):
-            with suppress(OSError):
-                cmd.secret_file.unlink()
+            if owned and path and path.exists():
+                with suppress(OSError):
+                    path.unlink()

--- a/cli/tests/integration/test_act_command_mutation.py
+++ b/cli/tests/integration/test_act_command_mutation.py
@@ -108,6 +108,4 @@ def test_act_command_mutation_and_cleanup(
         "executor-owned secret file must be removed after run"
     )
     assert cmd.event_file is not None
-    assert not cmd.event_file.exists(), (
-        "executor-owned event file must be removed after run"
-    )
+    assert not cmd.event_file.exists()

--- a/cli/tests/integration/test_act_command_mutation.py
+++ b/cli/tests/integration/test_act_command_mutation.py
@@ -61,6 +61,8 @@ def test_act_command_mutation_and_cleanup(
     assert cmd.secret_file is None
     assert not cmd._executor_owned_env_file
     assert not cmd._executor_owned_secret_file
+    assert cmd.event_file is not None
+    assert cmd._executor_owned_event_file
 
     mutation_during_run = False
 
@@ -104,4 +106,8 @@ def test_act_command_mutation_and_cleanup(
     )
     assert not cmd.secret_file.exists(), (
         "executor-owned secret file must be removed after run"
+    )
+    assert cmd.event_file is not None
+    assert not cmd.event_file.exists(), (
+        "executor-owned event file must be removed after run"
     )

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -813,7 +813,7 @@ class TestJobExecutor:
                 on_output=None,
             )
 
-    def test_cleanup_temp_files_preserves_caller_owned_paths(self, tmp_path):
+    def test_cleanup_temp_files_skips_unowned(self, tmp_path):
         event = tmp_path / "event.json"
         event.write_text("{}")
         secret = tmp_path / "secrets.env"

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -813,7 +813,7 @@ class TestJobExecutor:
                 on_output=None,
             )
 
-    def test_cleanup_temp_files(self, tmp_path):
+    def test_cleanup_temp_files_preserves_caller_owned_paths(self, tmp_path):
         event = tmp_path / "event.json"
         event.write_text("{}")
         secret = tmp_path / "secrets.env"
@@ -827,8 +827,21 @@ class TestJobExecutor:
         assert event.exists()
         assert secret.exists()
         JobExecutor._cleanup_temp_files(cmd)
-        assert not event.exists()
+        assert event.exists()
         assert secret.exists()
+
+    def test_cleanup_temp_files_deletes_executor_owned_event(self, tmp_path):
+        event = tmp_path / "localci-event-owned.json"
+        event.write_text("{}")
+        cmd = ActCommand(
+            workflow_file=Path("ci.yml"),
+            job_id="build",
+            event_file=event,
+        )
+        cmd._executor_owned_event_file = True
+        assert event.exists()
+        JobExecutor._cleanup_temp_files(cmd)
+        assert not event.exists()
 
     def test_cleanup_temp_files_deletes_executor_owned_secret(self, tmp_path):
         secret = tmp_path / "localci-secrets-owned.env"
@@ -1062,11 +1075,12 @@ class TestActCommandBuilder:
 
         assert cmd.event_file is not None
         assert cmd.event_file.exists()
+        assert cmd._executor_owned_event_file
         content = json.loads(cmd.event_file.read_text())
         assert "push" in content
 
-        # Cleanup
-        cmd.event_file.unlink()
+        JobExecutor._cleanup_temp_files(cmd)
+        assert not cmd.event_file.exists()
 
     def test_ccache_env_and_compress(self, tmp_path):
         """Issue 9: CCACHE_DIR, CCACHE_MAXSIZE, CCACHE_COMPRESS when cache enabled."""

--- a/cli/tests/test_run_flow.py
+++ b/cli/tests/test_run_flow.py
@@ -60,8 +60,6 @@ def sample_config() -> LocalCIConfig:
 
 
 class TestResolveMatrixFilters:
-    """CLI ``--matrix`` replaces (shadows) config ``matrix.include``; it does not merge."""
-
     def test_cli_matrix_shadows_config_include(self) -> None:
         cfg = LocalCIConfig(
             workflow=SAMPLE_WORKFLOW,
@@ -90,7 +88,7 @@ class TestResolveMatrixFilters:
         ]
         assert matrix_exclude is None
 
-    def test_matrix_exclude_always_from_config(self) -> None:
+    def test_matrix_exclude_from_config(self) -> None:
         cfg = LocalCIConfig(
             workflow=SAMPLE_WORKFLOW,
             matrix=MatrixConfig(

--- a/cli/tests/test_run_flow.py
+++ b/cli/tests/test_run_flow.py
@@ -11,8 +11,8 @@ from click.testing import CliRunner
 
 from localci.cli.run.container import build_run_container
 from localci.cli.run.params import RunOptions
-from localci.cli.run.run_flow import execute_run
-from localci.core.config import LocalCIConfig, PatchesConfig
+from localci.cli.run.run_flow import _resolve_matrix_filters, execute_run
+from localci.core.config import LocalCIConfig, MatrixConfig, MatrixFilter, PatchesConfig
 from localci.core.executor import ActNotFoundError
 from localci.core.workflow import (
     BuildSystem,
@@ -57,6 +57,51 @@ def _dry_run_options(**overrides: object) -> RunOptions:
 @pytest.fixture
 def sample_config() -> LocalCIConfig:
     return LocalCIConfig(workflow=SAMPLE_WORKFLOW)
+
+
+class TestResolveMatrixFilters:
+    """CLI ``--matrix`` replaces (shadows) config ``matrix.include``; it does not merge."""
+
+    def test_cli_matrix_shadows_config_include(self) -> None:
+        cfg = LocalCIConfig(
+            workflow=SAMPLE_WORKFLOW,
+            matrix=MatrixConfig(
+                include=[MatrixFilter(compiler="gcc", version="15", name="GCC 15")]
+            ),
+        )
+        options = _dry_run_options(
+            matrix_filters=("compiler=clang", "version=20"),
+        )
+        matrix_include, matrix_exclude = _resolve_matrix_filters(options, cfg)
+        assert matrix_include == [{"compiler": "clang", "version": "20"}]
+        assert matrix_exclude is None
+
+    def test_config_matrix_include_when_no_cli_filters(self) -> None:
+        cfg = LocalCIConfig(
+            workflow=SAMPLE_WORKFLOW,
+            matrix=MatrixConfig(
+                include=[MatrixFilter(compiler="gcc", version="15", name="GCC 15")]
+            ),
+        )
+        options = _dry_run_options(matrix_filters=())
+        matrix_include, matrix_exclude = _resolve_matrix_filters(options, cfg)
+        assert matrix_include == [
+            {"compiler": "gcc", "version": "15", "name": "GCC 15"}
+        ]
+        assert matrix_exclude is None
+
+    def test_matrix_exclude_always_from_config(self) -> None:
+        cfg = LocalCIConfig(
+            workflow=SAMPLE_WORKFLOW,
+            matrix=MatrixConfig(
+                include=[MatrixFilter(compiler="gcc", version="15")],
+                exclude=[MatrixFilter(compiler="clang", version="20")],
+            ),
+        )
+        options = _dry_run_options(matrix_filters=("compiler=gcc",))
+        matrix_include, matrix_exclude = _resolve_matrix_filters(options, cfg)
+        assert matrix_include == [{"compiler": "gcc"}]
+        assert matrix_exclude == [{"compiler": "clang", "version": "20"}]
 
 
 class TestExecuteRunDryRun:


### PR DESCRIPTION
## Summary

- Guard `_cleanup_temp_files` with `_executor_owned_event_file`, set by `ActCommandBuilder`.
- Add tests for `_resolve_matrix_filters`: CLI `--matrix` shadows config `matrix.include`; exclude stays on config.
- DRY temp-file cleanup into a single ownership loop.

Closes #82.

## Test plan

- [x] `pytest -m "not integration"`
- [x] `pre-commit run -a`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary event files created during local runs are now cleaned up automatically after execution.
  * Executor-owned temporary files (including event files) are removed, while user-provided event/env/secret files are preserved.
  * Matrix filter handling now correctly combines command-line filters with workflow configuration, including include and exclude rules.
* **Tests**
  * Expanded cleanup and mutation/cleanup contract coverage to validate executor-owned event file deletion.
  * Added/updated unit tests for matrix filter resolution behavior across include/exclude scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->