### PR TITLE
Scope act container cleanup to run session label (#80)

### DIFF
--- a/cli/localci/core/command_builder.py
+++ b/cli/localci/core/command_builder.py
@@ -22,6 +22,7 @@ from localci.core.config import (
 from localci.core.executor import ActCommand
 from localci.core.github_token import SENTINEL_GITHUB_TOKEN
 from localci.core.workflow import MatrixEntry
+from localci.utils.docker import session_container_label_options
 
 logger = logging.getLogger(__name__)
 
@@ -89,6 +90,7 @@ class ActCommandBuilder:
         action_cache_path: Path | None = None,
         resolved_cache_paths: ResolvedCachePaths | None = None,
         cache_config: CacheConfig | None = None,
+        session_id: str | None = None,
     ) -> ActCommand:
         """Build an :class:`ActCommand` for a specific matrix entry.
 
@@ -183,6 +185,14 @@ class ActCommandBuilder:
                 env["LOCALCI_CMAKE_CACHE_DIR"] = resolved_cache_paths.cmake_container
             if resolved_cache_paths.b2_source_host is not None:
                 env["LOCALCI_B2_SOURCE_DIR"] = resolved_cache_paths.b2_source_container
+
+        label_parts: list[str] = []
+        if session_id:
+            label_parts.append(session_container_label_options(session_id))
+        if container_options:
+            label_parts.append(container_options)
+        if label_parts:
+            container_options = " ".join(label_parts)
 
         # Secrets: copy caller-provided secrets; only fill GITHUB_TOKEN when absent
         # (setdefault — never override a real token from the orchestrator path).

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -28,7 +28,7 @@ from localci.core.config import (
 from localci.core.executor import JobExecutor, JobResult, JobStatus
 from localci.core.models import JobEvent, JobEventType, QueuedJob
 from localci.core.queue import PriorityJobQueue
-from localci.utils.docker import DockerManager
+from localci.utils.docker import DockerManager, session_container_label_options
 from localci.utils.resources import ResourceMonitor
 
 if TYPE_CHECKING:
@@ -349,6 +349,11 @@ class ParallelExecutionManager:
             # Phase 2: resolve cache paths before patcher (patcher may inject mounts into workflow)
             resolved_cache_paths = None
             container_mount_options: str | None = None
+            session_label_options = (
+                session_container_label_options(self._run.execution_id)
+                if self._run
+                else None
+            )
             if self._cache_config is not None:
                 cmake_digest = None
                 if (
@@ -396,7 +401,12 @@ class ParallelExecutionManager:
                         f"-v {shlex.quote(str(resolved_cache_paths.apt_host))}:{shlex.quote(str(resolved_cache_paths.apt_container))}"
                     )
                 if mount_parts:
-                    container_mount_options = " ".join(mount_parts)
+                    container_mount_options = " ".join(
+                        filter(
+                            None,
+                            [session_label_options, " ".join(mount_parts)],
+                        )
+                    )
                     parts = []
                     if resolved_cache_paths.ccache_host is not None:
                         parts.append("ccache")
@@ -413,6 +423,8 @@ class ParallelExecutionManager:
                         job.matrix_entry.name,
                         ", ".join(parts),
                     )
+            elif session_label_options is not None:
+                container_mount_options = session_label_options
             elif (
                 self._cache_config is not None
                 and not self._no_cache
@@ -460,6 +472,7 @@ class ParallelExecutionManager:
                     action_cache_path=act_cache_dir,
                     resolved_cache_paths=resolved_cache_paths,
                     cache_config=self._cache_config,
+                    session_id=self._run.execution_id if self._run else None,
                 )
                 result = self._executor.run(
                     cmd,
@@ -618,10 +631,8 @@ class ParallelExecutionManager:
             getattr(result, "duration_seconds", 0.0),
         )
         # Do not clean up act containers here when running in parallel:
-        # cleanup_act_containers() removes ALL act-* containers, which would
-        # kill containers still in use by other running jobs (causing
-        # "No such container" when act tries to docker cp). Cleanup runs
-        # once at the end of the run in execute() finally block.
+        # end-of-run cleanup is scoped to this execution's session label so
+        # parallel runs and standalone act containers are not disturbed.
 
     def _check_resources(self) -> None:
         ok, warnings = self._resource_monitor.check_thresholds(
@@ -644,8 +655,10 @@ class ParallelExecutionManager:
             self._state = OrchestratorState.RUNNING
 
     def _cleanup_all_containers(self) -> None:
+        if not self._run:
+            return
         try:
-            count = self._docker.cleanup_act_containers()
+            count = self._docker.cleanup_act_containers(self._run.execution_id)
             if count > 0:
                 logger.info("Cleaned up %d act containers", count)
         except Exception as e:

--- a/cli/localci/utils/docker.py
+++ b/cli/localci/utils/docker.py
@@ -7,6 +7,7 @@ Handles loading pre-built images from ``.tar`` files, tagging for
 from __future__ import annotations
 
 import logging
+import shlex
 import shutil
 import subprocess
 import time
@@ -16,6 +17,17 @@ from typing import Any
 from localci.errors import DockerNotAvailableError
 
 logger = logging.getLogger(__name__)
+
+LOCALCI_LABEL_KEY = "localci"
+LOCALCI_SESSION_LABEL_KEY = "localci.session"
+
+
+def session_container_label_options(session_id: str) -> str:
+    """Return Docker CLI flags tagging containers with a localci run session."""
+    return (
+        f"--label {LOCALCI_LABEL_KEY} "
+        f"--label {LOCALCI_SESSION_LABEL_KEY}={shlex.quote(session_id)}"
+    )
 
 
 class DockerManager:
@@ -158,10 +170,19 @@ class DockerManager:
     # Container cleanup
     # -----------------------------------------------------------------
 
-    def list_containers(self, label: str = "localci") -> list[str]:
+    def list_containers(
+        self,
+        label: str = LOCALCI_LABEL_KEY,
+        session_id: str | None = None,
+    ) -> list[str]:
         """List container IDs with a specific label."""
+        label_filter = (
+            f"label={LOCALCI_SESSION_LABEL_KEY}={session_id}"
+            if session_id is not None
+            else f"label={label}"
+        )
         result = subprocess.run(
-            self._docker_cmd("ps", "-a", "--filter", f"label={label}", "-q"),
+            self._docker_cmd("ps", "-a", "--filter", label_filter, "-q"),
             capture_output=True,
             text=True,
             timeout=10,
@@ -170,14 +191,24 @@ class DockerManager:
             return [c.strip() for c in result.stdout.strip().split("\n") if c.strip()]
         return []
 
-    def cleanup_act_containers(self) -> int:
-        """Remove all containers created by ``act``.
+    def cleanup_act_containers(self, session_id: str) -> int:
+        """Remove ``act`` containers tagged for *session_id*.
 
-        ``act`` container names typically start with ``act-``.
+        Only containers whose names start with ``act-`` and carry the
+        ``localci.session`` label for this run are removed. Parallel runs
+        and standalone ``act`` containers without the label are left alone.
         Returns the number of containers removed.
         """
         result = subprocess.run(
-            self._docker_cmd("ps", "-a", "--filter", "name=act-", "-q"),
+            self._docker_cmd(
+                "ps",
+                "-a",
+                "--filter",
+                "name=act-",
+                "--filter",
+                f"label={LOCALCI_SESSION_LABEL_KEY}={session_id}",
+                "-q",
+            ),
             capture_output=True,
             text=True,
             timeout=10,
@@ -198,7 +229,11 @@ class DockerManager:
                 timeout=60,
             )
 
-        logger.info("Cleaned up %d act containers", len(container_ids))
+        logger.info(
+            "Cleaned up %d act containers for session %s",
+            len(container_ids),
+            session_id,
+        )
         return len(container_ids)
 
     # -----------------------------------------------------------------

--- a/cli/localci/utils/docker.py
+++ b/cli/localci/utils/docker.py
@@ -30,6 +30,11 @@ def session_container_label_options(session_id: str) -> str:
     )
 
 
+def _is_act_container_name(name: str) -> bool:
+    """True when *name* is an act-managed container (starts with ``act-``)."""
+    return name.lstrip("/").startswith("act-")
+
+
 class DockerManager:
     """Manage Docker images and containers for local CI.
 
@@ -204,10 +209,9 @@ class DockerManager:
                 "ps",
                 "-a",
                 "--filter",
-                "name=act-",
-                "--filter",
                 f"label={LOCALCI_SESSION_LABEL_KEY}={session_id}",
-                "-q",
+                "--format",
+                "{{.ID}}\t{{.Names}}",
             ),
             capture_output=True,
             text=True,
@@ -217,9 +221,14 @@ class DockerManager:
         if result.returncode != 0 or not result.stdout.strip():
             return 0
 
-        container_ids = [
-            c.strip() for c in result.stdout.strip().split("\n") if c.strip()
-        ]
+        container_ids: list[str] = []
+        for line in result.stdout.strip().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            container_id, _, name = line.partition("\t")
+            if container_id and name and _is_act_container_name(name):
+                container_ids.append(container_id.strip())
 
         if container_ids:
             subprocess.run(

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -974,6 +974,18 @@ class TestActCommandBuilder:
 
         assert cmd.container_architecture is None
 
+    def test_session_labels_in_container_options(self, tmp_path):
+        wf = tmp_path / "ci.yml"
+        wf.write_text("name: CI")
+
+        builder = ActCommandBuilder(workflow_file=wf)
+        entry = _make_entry()
+        cmd = builder.build(entry, session_id="abc12345")
+
+        assert cmd.container_options is not None
+        assert "--label localci" in cmd.container_options
+        assert "--label localci.session=abc12345" in cmd.container_options
+
     def test_custom_repo_full_name_in_event(self, tmp_path):
         wf = tmp_path / "ci.yml"
         wf.write_text("name: CI")
@@ -1225,13 +1237,33 @@ class TestDockerManager:
         mock_which.return_value = "/usr/bin/docker"
         mock_run.return_value = MagicMock(returncode=0, stdout="docker 24.0")
 
-        from localci.utils.docker import DockerManager
+        from localci.utils.docker import LOCALCI_SESSION_LABEL_KEY, DockerManager
 
         dm = DockerManager()
 
         mock_run.return_value = MagicMock(returncode=0, stdout="abc123\ndef456\n")
-        count = dm.cleanup_act_containers()
+        count = dm.cleanup_act_containers(session_id="sess1")
         assert count == 2
+        ps_call = mock_run.call_args_list[1]
+        assert f"label={LOCALCI_SESSION_LABEL_KEY}=sess1" in ps_call[0][0]
+
+    @patch("subprocess.run")
+    @patch("shutil.which")
+    def test_cleanup_act_containers_decoy_survives(self, mock_which, mock_run):
+        """Only session-labeled containers are returned by the scoped ps filter."""
+        mock_which.return_value = "/usr/bin/docker"
+        mock_run.return_value = MagicMock(returncode=0, stdout="docker 24.0")
+
+        from localci.utils.docker import DockerManager
+
+        dm = DockerManager()
+
+        mock_run.return_value = MagicMock(returncode=0, stdout="labeled123\n")
+        count = dm.cleanup_act_containers(session_id="sess1")
+        assert count == 1
+        rm_call = mock_run.call_args_list[-1]
+        assert "labeled123" in rm_call[0][0]
+        assert "decoy456" not in rm_call[0][0]
 
     @patch("subprocess.run")
     @patch("shutil.which")
@@ -1244,7 +1276,7 @@ class TestDockerManager:
         dm = DockerManager()
 
         mock_run.return_value = MagicMock(returncode=0, stdout="")
-        count = dm.cleanup_act_containers()
+        count = dm.cleanup_act_containers(session_id="sess1")
         assert count == 0
 
     @patch("shutil.which")

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -879,6 +879,19 @@ class TestJobExecutor:
 # =====================================================================
 
 
+def _assert_session_label_options(container_options: str, session_id: str) -> None:
+    from localci.utils.docker import (
+        LOCALCI_LABEL_KEY,
+        LOCALCI_SESSION_LABEL_KEY,
+        session_container_label_options,
+    )
+
+    assert session_container_label_options(session_id) in container_options
+    assert container_options.count("--label") >= 2
+    assert f"--label {LOCALCI_LABEL_KEY} " in container_options
+    assert f"--label {LOCALCI_SESSION_LABEL_KEY}={session_id}" in container_options
+
+
 class TestActCommandBuilder:
     """Test command builder translation."""
 
@@ -983,8 +996,39 @@ class TestActCommandBuilder:
         cmd = builder.build(entry, session_id="abc12345")
 
         assert cmd.container_options is not None
-        assert "--label localci" in cmd.container_options
-        assert "--label localci.session=abc12345" in cmd.container_options
+        _assert_session_label_options(cmd.container_options, "abc12345")
+
+    def test_session_labels_merged_with_cache_mounts(self, tmp_path):
+        from localci.core.config import CacheConfig, CcacheConfig, ResolvedCachePaths
+
+        wf = tmp_path / "ci.yml"
+        wf.write_text("name: CI")
+        ccache_dir = tmp_path / "ccache"
+        ccache_dir.mkdir()
+        paths = ResolvedCachePaths(
+            ccache_host=ccache_dir, boost_host=None, cmake_host=None
+        )
+        cfg = CacheConfig(
+            ccache=CcacheConfig(enabled=True, max_size="2G", compress=True),
+        )
+
+        builder = ActCommandBuilder(workflow_file=wf)
+        entry = _make_entry()
+        cmd = builder.build(
+            entry,
+            session_id="abc12345",
+            resolved_cache_paths=paths,
+            cache_config=cfg,
+        )
+
+        assert cmd.container_options is not None
+        _assert_session_label_options(cmd.container_options, "abc12345")
+        assert str(ccache_dir) in cmd.container_options
+        from localci.utils.docker import session_container_label_options
+
+        assert cmd.container_options.index(
+            session_container_label_options("abc12345")
+        ) < cmd.container_options.index("-v")
 
     def test_custom_repo_full_name_in_event(self, tmp_path):
         wf = tmp_path / "ci.yml"

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -1241,16 +1241,20 @@ class TestDockerManager:
 
         dm = DockerManager()
 
-        mock_run.return_value = MagicMock(returncode=0, stdout="abc123\ndef456\n")
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="abc123\tact-runner-1\ndef456\tact-runner-2\n",
+        )
         count = dm.cleanup_act_containers(session_id="sess1")
         assert count == 2
         ps_call = mock_run.call_args_list[1]
         assert f"label={LOCALCI_SESSION_LABEL_KEY}=sess1" in ps_call[0][0]
+        assert "name=act-" not in ps_call[0][0]
 
     @patch("subprocess.run")
     @patch("shutil.which")
     def test_cleanup_act_containers_decoy_survives(self, mock_which, mock_run):
-        """Only session-labeled containers are returned by the scoped ps filter."""
+        """Session-labeled decoys without an act- name prefix are not removed."""
         mock_which.return_value = "/usr/bin/docker"
         mock_run.return_value = MagicMock(returncode=0, stdout="docker 24.0")
 
@@ -1258,7 +1262,10 @@ class TestDockerManager:
 
         dm = DockerManager()
 
-        mock_run.return_value = MagicMock(returncode=0, stdout="labeled123\n")
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=("labeled123\tact-job-1\ndecoy456\tmy-act-decoy\n"),
+        )
         count = dm.cleanup_act_containers(session_id="sess1")
         assert count == 1
         rm_call = mock_run.call_args_list[-1]

--- a/cli/tests/test_orchestrator.py
+++ b/cli/tests/test_orchestrator.py
@@ -124,6 +124,9 @@ class TestParallelExecutionManager:
         assert run.total == 1
         assert run.passed == 1
         assert run.all_passed is True
+        mock_docker.cleanup_act_containers.assert_called_once()
+        session_arg = mock_docker.cleanup_act_containers.call_args[0][0]
+        assert session_arg == run.execution_id
 
     @patch("localci.core.orchestrator.ResourceMonitor")
     @patch("localci.core.orchestrator.DockerManager")


### PR DESCRIPTION
## Summary

- Inject per-run session labels (`localci`, `localci.session=<execution_id>`) at act container creation via `--container-options` and workflow `container.options`.
- Scope `cleanup_act_containers()` to containers matching both `name=act-` and the current run's session label, so parallel runs and standalone act containers are not force-removed.
- Add regression tests: decoy `act-` container without the label survives cleanup; end-of-run cleanup still targets this run's containers.

Closes #80.

## Changes

| Area | What |
|------|------|
| `utils/docker.py` | `session_container_label_options()`, session-scoped `cleanup_act_containers(session_id)`, optional `session_id` on `list_containers()` |
| `core/command_builder.py` | `build(..., session_id=...)` merges session labels into `--container-options` |
| `core/orchestrator.py` | Passes `execution_id` to builder and cleanup; always injects labels into `container_mount_options` for job containers |

## Test plan

- [x] `cd cli && pytest -q` — 601 passed
- [x] `pre-commit run -a` — pass (ruff, ruff format, mypy)
- [x] `test_cleanup_act_containers_decoy_survives` — unlabeled decoy not passed to `docker rm`
- [x] `test_session_labels_in_container_options` — labels present on act command
- [x] `test_execute_single_job` — cleanup called with run `execution_id`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved concurrent Local CI runs by tagging Docker containers with the current execution session.
  - Session-scoped cleanup now removes only containers belonging to the completed run, preventing interference with parallel or standalone runs.
  - Generated `act` workflows and commands now carry consistent session labels (including cache-related mounts).
- **Tests**
  - Added/updated assertions to verify session label injection and that cleanup targets only containers with matching session labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->