### PR TITLE
Unsupported-platform jobs fail with an explicit Linux-only message (#79)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CHANGELOG.md` — this file
 - `.github/CODEOWNERS` — maintainer routing for reviews
 - `patches.profile` — `generic` (default) or `capy`; opt-in profile for Boost.Capy/B2 workflow patches and project identity
+- **Unsupported-platform handling** — Windows and macOS matrix entries fail with an explicit Linux-only message (job name, platform, `runs-on`) instead of invoking act without an image; set `platforms.windows` / `platforms.macos` to `true` to skip those jobs without failing the run
 
 ### Changed
 

--- a/cli/Usage Guide.md
+++ b/cli/Usage Guide.md
@@ -216,11 +216,11 @@ parallel:
     cpu_percent: 80        # Pause new jobs above this CPU usage
     memory_percent: 70     # Pause new jobs above this memory usage
 
-# Which platforms to enable
+# Which platforms to run locally (Linux-only execution)
 platforms:
   linux: true
-  windows: false           # Requires Windows host with Docker Desktop
-  macos: false             # Not containerisable
+  windows: false           # false: fail loud; true: skip Windows jobs without failing run
+  macos: false             # false: fail loud; true: skip macOS jobs without failing run
 
 # Job filters
 jobs:
@@ -300,12 +300,25 @@ execution:
 
 There is no CLI flag for `stop_on_first_failure`; set it in `.localci.yml` or with `localci config set execution.stop_on_first_failure true`.
 
+#### Platform support
+
+Local CI runs Linux jobs in Docker via act. Windows and macOS matrix entries are
+**not executable** on the Linux container path.
+
+| Config | Windows / macOS jobs in workflow |
+|--------|----------------------------------|
+| `platforms.windows: false` / `platforms.macos: false` (default) | **Fail** with an explicit message naming the job, platform, and `runs-on` value |
+| `platforms.windows: true` / `platforms.macos: true` | **Skip** without failing the overall run |
+
+Use `--platform linux` to queue only Linux matrix entries. Linux jobs honor
+`platforms.linux` (when `false`, Linux entries are skipped).
+
 #### Key sections
 
 | Section | Purpose |
 |---------|---------|
 | `parallel` | Control how many jobs run at once and resource limits |
-| `platforms` | Enable/disable Linux, Windows, macOS jobs |
+| `platforms` | Enable Linux jobs; opt-in skip for Windows/macOS (see below) |
 | `jobs` | Include or exclude specific job names |
 | `matrix` | Filter matrix entries by compiler, version, asan, etc. |
 | `priorities` | Override execution order (lower number runs first) |

--- a/cli/localci/cli/run/patcher.py
+++ b/cli/localci/cli/run/patcher.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 from pathlib import Path
 
 from localci.core.config import LocalCIConfig
+from localci.core.models import PlatformOutcome
 from localci.core.patch_pipeline import PatchContext, PatchPipeline
 from localci.core.queue import PriorityJobQueue
 from localci.core.workflow import MatrixEntry
@@ -31,17 +32,27 @@ def _print_execution_plan(
     table.add_column("#", justify="right", style="dim")
     table.add_column("Name", style="bold")
     table.add_column("Compiler", style="cyan")
+    table.add_column("Outcome")
     table.add_column("Image")
     for job in sorted(
         queue.get_all_jobs(),
         key=lambda j: (j.priority, j.matrix_entry.index),
     ):
+        outcome = job.platform_outcome.value
+        outcome_style = {
+            PlatformOutcome.RUN.value: "green",
+            PlatformOutcome.FAIL.value: "red",
+            PlatformOutcome.SKIP.value: "yellow",
+        }.get(outcome, "white")
         table.add_row(
             str(job.priority),
             str(job.matrix_entry.index),
             job.matrix_entry.name,
             f"{job.matrix_entry.compiler.family.value}-{job.matrix_entry.compiler.version}",
-            job.image_tag or "none",
+            f"[{outcome_style}]{outcome}[/{outcome_style}]",
+            job.image_tag or "none"
+            if job.platform_outcome == PlatformOutcome.RUN
+            else "-",
         )
     console.print(table)
     summary = queue.get_priority_summary()

--- a/cli/localci/cli/run/run_flow.py
+++ b/cli/localci/cli/run/run_flow.py
@@ -93,6 +93,7 @@ def execute_run(
         matrix_exclude=matrix_exclude,
         entries_include=selected_set,
         registry_path=registry_path,
+        platform_config=cfg.platforms,
     )
 
     if options.dry_run:

--- a/cli/localci/core/config.py
+++ b/cli/localci/core/config.py
@@ -46,7 +46,12 @@ class ParallelConfig(BaseModel):
 
 
 class PlatformConfig(BaseModel):
-    """Which platforms to run locally."""
+    """Which platforms to run locally.
+
+    Local CI executes Linux jobs in Docker. Windows and macOS workflow entries
+    are not runnable; with the platform flag off (default) they fail loud,
+    and when set to ``true`` they are skipped without failing the run.
+    """
 
     linux: bool = True
     windows: bool = False

--- a/cli/localci/core/models.py
+++ b/cli/localci/core/models.py
@@ -55,6 +55,14 @@ class JobEventType(Enum):
     ALL_COMPLETE = "all_complete"
 
 
+class PlatformOutcome(str, Enum):
+    """How a queued job should be handled based on platform config."""
+
+    RUN = "run"
+    FAIL = "fail"
+    SKIP = "skip"
+
+
 # ---------------------------------------------------------------------------
 # Data classes
 # ---------------------------------------------------------------------------
@@ -73,6 +81,7 @@ class QueuedJob:
         None  # When needs_build, tag of base image to build from
     )
     needs_build: bool = False
+    platform_outcome: PlatformOutcome = PlatformOutcome.RUN
     status: QueuedJobStatus = field(default=QueuedJobStatus.QUEUED)
 
     @property

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -362,6 +362,16 @@ class ParallelExecutionManager:
                         job.job_id, job.matrix_entry
                     ),
                 )
+            if job.platform_outcome == PlatformOutcome.FAIL:
+                return JobResult(
+                    job_id=job.job_id,
+                    matrix_index=job.matrix_entry.index,
+                    matrix_name=job.matrix_entry.name,
+                    status=JobStatus.FAILED,
+                    error_message=unsupported_platform_message(
+                        job.job_id, job.matrix_entry
+                    ),
+                )
             if job.matrix_entry.platform != Platform.LINUX:
                 return JobResult(
                     job_id=job.job_id,

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -26,8 +26,13 @@ from localci.core.config import (
     resolve_cache_paths,
 )
 from localci.core.executor import JobExecutor, JobResult, JobStatus
-from localci.core.models import JobEvent, JobEventType, QueuedJob
+from localci.core.models import JobEvent, JobEventType, PlatformOutcome, QueuedJob
+from localci.core.platform_support import (
+    skipped_platform_message,
+    unsupported_platform_message,
+)
 from localci.core.queue import PriorityJobQueue
+from localci.core.workflow import Platform
 from localci.utils.docker import DockerManager, session_container_label_options
 from localci.utils.resources import ResourceMonitor
 
@@ -139,7 +144,12 @@ class ExecutionRun:
 
     @property
     def all_passed(self) -> bool:
-        return self.failed == 0 and self.total > 0
+        if self.total == 0:
+            return False
+        return all(
+            r.status in (JobStatus.PASSED, JobStatus.SKIPPED)
+            for r in self.results.values()
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -335,6 +345,27 @@ class ParallelExecutionManager:
 
     def _execute_job(self, job: QueuedJob) -> JobResult:
         try:
+            if job.platform_outcome == PlatformOutcome.FAIL:
+                return JobResult(
+                    job_id=job.job_id,
+                    matrix_index=job.matrix_entry.index,
+                    matrix_name=job.matrix_entry.name,
+                    status=JobStatus.FAILED,
+                    error_message=unsupported_platform_message(
+                        job.job_id, job.matrix_entry
+                    ),
+                )
+            if job.platform_outcome == PlatformOutcome.SKIP:
+                return JobResult(
+                    job_id=job.job_id,
+                    matrix_index=job.matrix_entry.index,
+                    matrix_name=job.matrix_entry.name,
+                    status=JobStatus.SKIPPED,
+                    error_message=skipped_platform_message(
+                        job.job_id, job.matrix_entry
+                    ),
+                )
+
             self.queue.mark_preparing(job)
             image_tag = self._prepare_image(job)
             if job.image_tag and image_tag is None:
@@ -344,6 +375,16 @@ class ParallelExecutionManager:
                     matrix_name=job.matrix_entry.name,
                     status=JobStatus.ERROR,
                     error_message=f"Image not available: {job.image_tag} (not in Docker cache and load from .tar failed or not attempted)",
+                )
+            if image_tag is None and job.matrix_entry.platform != Platform.LINUX:
+                return JobResult(
+                    job_id=job.job_id,
+                    matrix_index=job.matrix_entry.index,
+                    matrix_name=job.matrix_entry.name,
+                    status=JobStatus.FAILED,
+                    error_message=unsupported_platform_message(
+                        job.job_id, job.matrix_entry
+                    ),
                 )
             self.queue.mark_running(job)
             # Phase 2: resolve cache paths before patcher (patcher may inject mounts into workflow)
@@ -615,18 +656,25 @@ class ParallelExecutionManager:
             )
         if self._run:
             self._run.results[job.queue_key] = result
-        success = result.status == JobStatus.PASSED
-        self.queue.mark_completed(job, success=success)
-        if result.status == JobStatus.TIMEOUT:
-            event_type = JobEventType.JOB_TIMEOUT
-        elif success:
+        if result.status == JobStatus.SKIPPED:
+            self.queue.mark_skipped(job)
             event_type = JobEventType.JOB_COMPLETED
+            success = False
         else:
-            event_type = JobEventType.JOB_FAILED
+            success = result.status == JobStatus.PASSED
+            self.queue.mark_completed(job, success=success)
+            if result.status == JobStatus.TIMEOUT:
+                event_type = JobEventType.JOB_TIMEOUT
+            elif success:
+                event_type = JobEventType.JOB_COMPLETED
+            else:
+                event_type = JobEventType.JOB_FAILED
         self._emit(event_type, job, result=result)
         logger.info(
             "%s: %s (%.1fs)",
-            "PASSED" if success else "FAILED",
+            "PASSED"
+            if success
+            else ("SKIPPED" if result.status == JobStatus.SKIPPED else "FAILED"),
             job.matrix_entry.name,
             getattr(result, "duration_seconds", 0.0),
         )

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -247,6 +247,12 @@ class ParallelExecutionManager:
             self.config.max_parallel,
         )
 
+        if self.queue.total_jobs == 0:
+            logger.warning("No jobs in queue; nothing to execute")
+            self._run.finished_at = datetime.now()
+            self._run.state = OrchestratorState.COMPLETED
+            return self._run
+
         try:
             sig = getattr(signal, "SIGINT", None)
             original_sigint = signal.signal(sig, self._handle_sigint) if sig else None
@@ -345,16 +351,6 @@ class ParallelExecutionManager:
 
     def _execute_job(self, job: QueuedJob) -> JobResult:
         try:
-            if job.platform_outcome == PlatformOutcome.FAIL:
-                return JobResult(
-                    job_id=job.job_id,
-                    matrix_index=job.matrix_entry.index,
-                    matrix_name=job.matrix_entry.name,
-                    status=JobStatus.FAILED,
-                    error_message=unsupported_platform_message(
-                        job.job_id, job.matrix_entry
-                    ),
-                )
             if job.platform_outcome == PlatformOutcome.SKIP:
                 return JobResult(
                     job_id=job.job_id,
@@ -362,6 +358,16 @@ class ParallelExecutionManager:
                     matrix_name=job.matrix_entry.name,
                     status=JobStatus.SKIPPED,
                     error_message=skipped_platform_message(
+                        job.job_id, job.matrix_entry
+                    ),
+                )
+            if job.matrix_entry.platform != Platform.LINUX:
+                return JobResult(
+                    job_id=job.job_id,
+                    matrix_index=job.matrix_entry.index,
+                    matrix_name=job.matrix_entry.name,
+                    status=JobStatus.FAILED,
+                    error_message=unsupported_platform_message(
                         job.job_id, job.matrix_entry
                     ),
                 )
@@ -375,16 +381,6 @@ class ParallelExecutionManager:
                     matrix_name=job.matrix_entry.name,
                     status=JobStatus.ERROR,
                     error_message=f"Image not available: {job.image_tag} (not in Docker cache and load from .tar failed or not attempted)",
-                )
-            if image_tag is None and job.matrix_entry.platform != Platform.LINUX:
-                return JobResult(
-                    job_id=job.job_id,
-                    matrix_index=job.matrix_entry.index,
-                    matrix_name=job.matrix_entry.name,
-                    status=JobStatus.FAILED,
-                    error_message=unsupported_platform_message(
-                        job.job_id, job.matrix_entry
-                    ),
                 )
             self.queue.mark_running(job)
             # Phase 2: resolve cache paths before patcher (patcher may inject mounts into workflow)

--- a/cli/localci/core/orchestrator.py
+++ b/cli/localci/core/orchestrator.py
@@ -251,6 +251,7 @@ class ParallelExecutionManager:
             logger.warning("No jobs in queue; nothing to execute")
             self._run.finished_at = datetime.now()
             self._run.state = OrchestratorState.COMPLETED
+            self._state = OrchestratorState.COMPLETED
             return self._run
 
         try:

--- a/cli/localci/core/platform_support.py
+++ b/cli/localci/core/platform_support.py
@@ -1,0 +1,54 @@
+"""Platform enablement and unsupported-platform messaging for local CI."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from localci.core.models import PlatformOutcome
+from localci.core.workflow import MatrixEntry, Platform
+
+if TYPE_CHECKING:
+    from localci.core.config import PlatformConfig
+
+
+def resolve_platform_outcome(
+    entry: MatrixEntry,
+    config: PlatformConfig,
+) -> PlatformOutcome:
+    """Resolve whether a matrix entry should run, fail, or skip.
+
+    Windows and macOS jobs are not runnable under act on Linux. With the
+    platform flag off (default), they fail loud. Setting
+    ``platforms.windows`` or ``platforms.macos`` to ``true`` opts in to
+    skipping those jobs without failing the overall run.
+    """
+    platform = entry.platform
+    if platform == Platform.LINUX:
+        return PlatformOutcome.RUN if config.linux else PlatformOutcome.SKIP
+    if platform == Platform.WINDOWS:
+        return PlatformOutcome.SKIP if config.windows else PlatformOutcome.FAIL
+    if platform == Platform.MACOS:
+        return PlatformOutcome.SKIP if config.macos else PlatformOutcome.FAIL
+    return PlatformOutcome.FAIL
+
+
+def unsupported_platform_message(job_id: str, entry: MatrixEntry) -> str:
+    """Explicit failure message for a non-Linux matrix entry."""
+    platform = entry.platform.value
+    return (
+        f"Job '{job_id}' / '{entry.name}' uses platform '{platform}' "
+        f"(runs-on: {entry.runs_on}). Local CI supports Linux jobs only. "
+        f"Set platforms.{platform}: true in .localci.yml to skip {platform} "
+        f"jobs without failing the run, or use --platform linux to run only "
+        f"Linux matrix entries."
+    )
+
+
+def skipped_platform_message(job_id: str, entry: MatrixEntry) -> str:
+    """Message when an unsupported platform job is skipped via config."""
+    platform = entry.platform.value
+    return (
+        f"Skipped job '{job_id}' / '{entry.name}': platform '{platform}' "
+        f"(runs-on: {entry.runs_on}) is not supported by local CI (Linux-only; "
+        f"platforms.{platform}: true)."
+    )

--- a/cli/localci/core/progress.py
+++ b/cli/localci/core/progress.py
@@ -17,7 +17,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from localci.core.executor import JobResult
+from localci.core.executor import JobResult, JobStatus
 from localci.core.models import (
     JobEvent,
     JobEventType,
@@ -283,9 +283,13 @@ class ProgressTracker:
                         (prev_name, (ts - prev_start).total_seconds())
                     )
                 progress.current_step = None
-                progress.status = QueuedJobStatus.PASSED
                 progress.finished_at = ts
                 result = event.data.get("result")
+                if isinstance(result, JobResult) and result.status == JobStatus.SKIPPED:
+                    progress.status = QueuedJobStatus.SKIPPED
+                    progress.error_message = result.error_message
+                else:
+                    progress.status = QueuedJobStatus.PASSED
                 if isinstance(result, JobResult):
                     progress.duration_seconds = result.duration_seconds
                     progress.exit_code = result.exit_code

--- a/cli/localci/core/progress.py
+++ b/cli/localci/core/progress.py
@@ -647,11 +647,8 @@ class ProgressTracker:
                 QueuedJobStatus.TIMEOUT,
             )
         ]
-        cancelled = [
-            j
-            for j in jobs
-            if j.status in (QueuedJobStatus.CANCELLED, QueuedJobStatus.SKIPPED)
-        ]
+        cancelled = [j for j in jobs if j.status == QueuedJobStatus.CANCELLED]
+        skipped = [j for j in jobs if j.status == QueuedJobStatus.SKIPPED]
         running = [
             j
             for j in jobs
@@ -670,7 +667,7 @@ class ProgressTracker:
         ]
 
         total = len(jobs)
-        done = len(completed) + len(failed) + len(cancelled)
+        done = len(completed) + len(failed) + len(cancelled) + len(skipped)
 
         result = {
             "progress": f"{done}/{total} jobs completed",
@@ -680,6 +677,7 @@ class ProgressTracker:
             "passed_count": len(completed),
             "failed_count": len(failed),
             "cancelled_count": len(cancelled),
+            "skipped_count": len(skipped),
             "running_count": len(running),
             "pending_count": len(pending),
             "elapsed_seconds": self._elapsed_seconds(),
@@ -746,6 +744,16 @@ class ProgressTracker:
                     "status": j.status.value,
                 }
                 for j in pending
+            ],
+            "skipped_jobs": [
+                {
+                    "name": j.name,
+                    "index": j.index,
+                    "priority": j.priority,
+                    "status": j.status.value,
+                    "error_message": j.error_message,
+                }
+                for j in skipped
             ],
             "priority_levels": {
                 level.priority: {

--- a/cli/localci/core/queue.py
+++ b/cli/localci/core/queue.py
@@ -249,6 +249,14 @@ class PriorityJobQueue:
             self._running_keys.discard(key)
             self._check_priority_advance()
 
+    def mark_skipped(self, job: QueuedJob) -> None:
+        with self._lock:
+            key = job.queue_key
+            job.status = QueuedJobStatus.SKIPPED
+            self._completed_keys.add(key)
+            self._running_keys.discard(key)
+            self._check_priority_advance()
+
     def mark_running(self, job: QueuedJob) -> None:
         with self._lock:
             job.status = QueuedJobStatus.RUNNING

--- a/cli/localci/core/queue_builder.py
+++ b/cli/localci/core/queue_builder.py
@@ -7,8 +7,10 @@ import logging
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from localci.core.config import PlatformConfig
 from localci.core.image_tag import derive_image_tag
 from localci.core.models import QueuedJob
+from localci.core.platform_support import resolve_platform_outcome
 from localci.core.queue import PriorityConfig, PriorityJobQueue
 from localci.core.workflow import MatrixEntry, Platform
 
@@ -100,9 +102,11 @@ class QueueBuilder:
         matrix_exclude: list[dict[str, Any]] | None = None,
         entries_include: set[tuple[str, int]] | None = None,
         registry_path: Path | None = None,
+        platform_config: PlatformConfig | None = None,
     ) -> PriorityJobQueue:
         """Build queue. entries_include: when set, only (job_id, entry.index) in this set."""
         queue = PriorityJobQueue()
+        plat_cfg = platform_config or PlatformConfig()
 
         # First pass: collect (job, entry) that pass filters and build job_id -> [keys]
         job_keys: dict[str, list[str]] = {}
@@ -155,6 +159,7 @@ class QueueBuilder:
                 image_tag=image_tag,
                 base_image_tag=base_image_tag,
                 needs_build=needs_build,
+                platform_outcome=resolve_platform_outcome(entry, plat_cfg),
             )
             queued.priority = self.priority_config.resolve_priority(queued)
             queue.enqueue(queued)

--- a/cli/localci/core/queue_builder.py
+++ b/cli/localci/core/queue_builder.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from localci.core.config import PlatformConfig
 from localci.core.image_tag import derive_image_tag
-from localci.core.models import QueuedJob
+from localci.core.models import PlatformOutcome, QueuedJob
 from localci.core.platform_support import resolve_platform_outcome
 from localci.core.queue import PriorityConfig, PriorityJobQueue
 from localci.core.workflow import MatrixEntry, Platform
@@ -147,9 +147,13 @@ class QueueBuilder:
             dep_keys = []
             for dep in job.needs:
                 dep_keys.extend(job_keys.get(dep, []))
-            image_tag, base_image_tag, needs_build = _resolve_image_tag_and_build(
-                entry, registry
-            )
+            platform_outcome = resolve_platform_outcome(entry, plat_cfg)
+            if platform_outcome == PlatformOutcome.RUN:
+                image_tag, base_image_tag, needs_build = _resolve_image_tag_and_build(
+                    entry, registry
+                )
+            else:
+                image_tag, base_image_tag, needs_build = None, None, False
 
             queued = QueuedJob(
                 job_id=job.id,
@@ -159,7 +163,7 @@ class QueueBuilder:
                 image_tag=image_tag,
                 base_image_tag=base_image_tag,
                 needs_build=needs_build,
-                platform_outcome=resolve_platform_outcome(entry, plat_cfg),
+                platform_outcome=platform_outcome,
             )
             queued.priority = self.priority_config.resolve_priority(queued)
             queue.enqueue(queued)

--- a/cli/localci/core/results.py
+++ b/cli/localci/core/results.py
@@ -64,13 +64,17 @@ class ExecutionSummary:
 
     @property
     def all_passed(self) -> bool:
-        """Whether every job passed.
+        """Whether every job passed or was intentionally skipped.
 
         Note: returns ``True`` for an empty summary (no jobs).  This is
         intentional -- an empty run has no failures -- but callers should
         check :attr:`total` separately when a zero-job run is unexpected.
         """
-        return self.failed == 0 and self.errors == 0 and self.completed == self.total
+        if self.total == 0:
+            return True
+        return all(
+            r.status in (JobStatus.PASSED, JobStatus.SKIPPED) for r in self.results
+        )
 
     # -----------------------------------------------------------------
     # Timing

--- a/cli/localci/core/results.py
+++ b/cli/localci/core/results.py
@@ -115,6 +115,7 @@ class ExecutionSummary:
             f"Passed:   {self.passed}",
             f"Failed:   {self.failed}",
             f"Errors:   {self.errors}",
+            f"Skipped:  {self.skipped}",
             f"Duration: {self.total_duration:.1f}s",
             "",
         ]
@@ -165,6 +166,7 @@ class ExecutionSummary:
             "passed": self.passed,
             "failed": self.failed,
             "errors": self.errors,
+            "skipped": self.skipped,
             "duration": self.total_duration,
             "results": [
                 {

--- a/cli/localci/core/results.py
+++ b/cli/localci/core/results.py
@@ -47,6 +47,10 @@ class ExecutionSummary:
         )
 
     @property
+    def skipped(self) -> int:
+        return sum(1 for r in self.results if r.status == JobStatus.SKIPPED)
+
+    @property
     def pending(self) -> int:
         return sum(
             1
@@ -60,18 +64,13 @@ class ExecutionSummary:
 
     @property
     def completed(self) -> int:
-        return self.passed + self.failed + self.errors
+        return self.passed + self.failed + self.errors + self.skipped
 
     @property
     def all_passed(self) -> bool:
-        """Whether every job passed or was intentionally skipped.
-
-        Note: returns ``True`` for an empty summary (no jobs).  This is
-        intentional -- an empty run has no failures -- but callers should
-        check :attr:`total` separately when a zero-job run is unexpected.
-        """
+        """Whether every job passed or was intentionally skipped."""
         if self.total == 0:
-            return True
+            return False
         return all(
             r.status in (JobStatus.PASSED, JobStatus.SKIPPED) for r in self.results
         )

--- a/cli/localci/templates/localci.yml
+++ b/cli/localci/templates/localci.yml
@@ -18,11 +18,11 @@ parallel:
     cpu_percent: 80        # Max CPU usage before throttling
     memory_percent: 70     # Max memory usage before throttling
 
-# Platform configuration
+# Platform configuration (Linux-only execution)
 platforms:
   linux: true              # Enable Linux jobs
-  windows: false           # Disable Windows (requires Windows host)
-  macos: false             # Disable macOS (not containerisable)
+  windows: false           # false: fail loud; true: skip without failing run
+  macos: false             # false: fail loud; true: skip without failing run
 
 # Job filters
 jobs:

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -1462,6 +1462,7 @@ class TestExecutionSummary:
         assert d["total"] == 1
         assert d["passed"] == 1
         assert d["failed"] == 0
+        assert d["skipped"] == 0
         assert len(d["results"]) == 1
 
     def test_load_with_missing_finished_at(self, tmp_path):

--- a/cli/tests/test_executor.py
+++ b/cli/tests/test_executor.py
@@ -1421,7 +1421,7 @@ class TestExecutionSummary:
             started_at=datetime.now(),
         )
         assert summary.total == 0
-        assert summary.all_passed is True
+        assert summary.all_passed is False
         assert summary.longest_job is None
         assert summary.shortest_job is None
 

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -305,6 +305,31 @@ class TestOrchestratorUnsupportedPlatform:
 
 
 class TestExecutionSummarySkipped:
+    def test_all_skipped_run_is_all_passed(self) -> None:
+        """Zero PASSED, all SKIPPED must still count as a clean run."""
+        from datetime import datetime
+
+        summary = ExecutionSummary(
+            execution_id="test",
+            started_at=datetime.now(),
+            results=[
+                JobResult(
+                    job_id="build",
+                    matrix_index=0,
+                    matrix_name="MSVC",
+                    status=JobStatus.SKIPPED,
+                ),
+                JobResult(
+                    job_id="build",
+                    matrix_index=1,
+                    matrix_name="Apple-Clang",
+                    status=JobStatus.SKIPPED,
+                ),
+            ],
+        )
+        assert summary.passed == 0
+        assert summary.all_passed is True
+
     def test_skipped_jobs_allow_all_passed(self) -> None:
         from datetime import datetime
 

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -28,6 +28,13 @@ class TestResolvePlatformOutcome:
         entry = make_entry("GCC 15", platform=Platform.LINUX)
         assert resolve_platform_outcome(entry, PlatformConfig()) == PlatformOutcome.RUN
 
+    def test_linux_disabled_skips(self) -> None:
+        entry = make_entry("GCC 15", platform=Platform.LINUX)
+        assert (
+            resolve_platform_outcome(entry, PlatformConfig(linux=False))
+            == PlatformOutcome.SKIP
+        )
+
     def test_windows_default_fails(self) -> None:
         entry = make_entry("MSVC", platform=Platform.WINDOWS, compiler="msvc")
         entry.runs_on = "windows-2022"
@@ -154,6 +161,44 @@ class TestOrchestratorUnsupportedPlatform:
     @patch("localci.core.orchestrator.ResourceMonitor")
     @patch("localci.core.orchestrator.DockerManager")
     @patch("localci.core.orchestrator.JobExecutor")
+    def test_non_linux_run_outcome_still_rejected(
+        self, MockExecutor, MockDocker, MockMonitor, tmp_path: Path
+    ) -> None:
+        mock_executor = MockExecutor.return_value
+        mock_docker = MockDocker.return_value
+        mock_docker.image_exists.return_value = True
+        mock_docker.cleanup_act_containers.return_value = 0
+        mock_monitor = MockMonitor.return_value
+        mock_monitor.check_thresholds.return_value = (True, [])
+        mock_monitor.snapshot.return_value = MagicMock(summary=lambda: "OK")
+
+        entry = make_entry("MSVC 14.42", platform=Platform.WINDOWS, compiler="msvc")
+        entry.runs_on = "windows-2022"
+        job = make_job("MSVC 14.42", compiler="msvc")
+        job.matrix_entry = entry
+        job.platform_outcome = PlatformOutcome.RUN
+        job.image_tag = "some-image:latest"
+
+        queue = PriorityJobQueue()
+        queue.enqueue(job)
+
+        orchestrator = ParallelExecutionManager(
+            queue=queue,
+            workflow_file=Path("ci.yml"),
+            config=OrchestratorConfig(max_parallel=1),
+            logs_dir=tmp_path / "logs",
+        )
+        run = orchestrator.execute()
+
+        assert run.failed == 1
+        result = next(iter(run.results.values()))
+        assert result.status == JobStatus.FAILED
+        assert "Linux jobs only" in (result.error_message or "")
+        mock_executor.run.assert_not_called()
+
+    @patch("localci.core.orchestrator.ResourceMonitor")
+    @patch("localci.core.orchestrator.DockerManager")
+    @patch("localci.core.orchestrator.JobExecutor")
     def test_mixed_platform_no_clean_pass_with_default_config(
         self, MockExecutor, MockDocker, MockMonitor, tmp_path: Path
     ) -> None:
@@ -174,12 +219,6 @@ class TestOrchestratorUnsupportedPlatform:
 
         analyzer = WorkflowAnalyzer()
         workflow = analyzer.analyze(SAMPLE_WORKFLOW)
-        queue = QueueBuilder(workflow).build(
-            platform_filter=Platform.LINUX,
-            platform_config=PlatformConfig(),
-        )
-        # Include one failing windows job alongside linux-only filter bypass test:
-        # build full mixed queue like a default run (no platform filter).
         queue = QueueBuilder(workflow).build(platform_config=PlatformConfig())
         linux_job = next(
             j for j in queue.get_all_jobs() if j.platform_outcome == PlatformOutcome.RUN
@@ -187,7 +226,8 @@ class TestOrchestratorUnsupportedPlatform:
         windows_job = next(
             j
             for j in queue.get_all_jobs()
-            if j.platform_outcome == PlatformOutcome.FAIL
+            if j.matrix_entry.platform == Platform.WINDOWS
+            and j.platform_outcome == PlatformOutcome.FAIL
         )
 
         mixed_queue = PriorityJobQueue()
@@ -309,3 +349,45 @@ class TestExecutionSummarySkipped:
             ],
         )
         assert summary.all_passed is False
+
+    def test_progress_line_counts_skipped(self) -> None:
+        from datetime import datetime
+
+        summary = ExecutionSummary(
+            execution_id="test",
+            started_at=datetime.now(),
+            results=[
+                JobResult(
+                    job_id="build",
+                    matrix_index=0,
+                    matrix_name="GCC 15",
+                    status=JobStatus.PASSED,
+                ),
+                JobResult(
+                    job_id="build",
+                    matrix_index=1,
+                    matrix_name="MSVC",
+                    status=JobStatus.SKIPPED,
+                ),
+            ],
+        )
+        assert summary.completed == 2
+        assert summary.progress_line() == "2/2 jobs completed"
+
+
+class TestOrchestratorEmptyQueue:
+    @patch("localci.core.orchestrator.DockerManager")
+    def test_execute_empty_queue_returns_immediately(
+        self, MockDocker, tmp_path: Path
+    ) -> None:
+        MockDocker.return_value.cleanup_act_containers.return_value = 0
+        queue = PriorityJobQueue()
+        orchestrator = ParallelExecutionManager(
+            queue=queue,
+            workflow_file=Path("ci.yml"),
+            config=OrchestratorConfig(max_parallel=1),
+            logs_dir=tmp_path / "logs",
+        )
+        run = orchestrator.execute()
+        assert run.total == 0
+        assert run.all_passed is False

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -100,6 +100,8 @@ class TestQueueBuilderPlatformOutcomes:
         assert all(j.platform_outcome == PlatformOutcome.FAIL for j in windows_jobs)
         assert all(j.platform_outcome == PlatformOutcome.FAIL for j in macos_jobs)
         assert all(j.platform_outcome == PlatformOutcome.RUN for j in linux_jobs)
+        assert all(j.image_tag is not None for j in linux_jobs)
+        assert all(j.image_tag is None for j in windows_jobs + macos_jobs)
 
     def test_mixed_platform_opt_in_skip(self) -> None:
         analyzer = WorkflowAnalyzer()
@@ -325,6 +327,31 @@ class TestExecutionSummarySkipped:
             ],
         )
         assert summary.all_passed is True
+
+    def test_summary_report_includes_skipped_count(self) -> None:
+        from datetime import datetime
+
+        summary = ExecutionSummary(
+            execution_id="test",
+            started_at=datetime.now(),
+            results=[
+                JobResult(
+                    job_id="build",
+                    matrix_index=0,
+                    matrix_name="GCC 15",
+                    status=JobStatus.PASSED,
+                ),
+                JobResult(
+                    job_id="build",
+                    matrix_index=1,
+                    matrix_name="MSVC",
+                    status=JobStatus.SKIPPED,
+                ),
+            ],
+        )
+        report = summary.summary_report()
+        assert "Skipped:  1" in report
+        assert "ALL PASSED" in report
 
     def test_failed_unsupported_blocks_all_passed(self) -> None:
         from datetime import datetime

--- a/cli/tests/test_platform_support.py
+++ b/cli/tests/test_platform_support.py
@@ -1,0 +1,311 @@
+"""Tests for unsupported-platform handling (issue #79)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from localci.core.config import PlatformConfig
+from localci.core.executor import JobResult, JobStatus
+from localci.core.models import PlatformOutcome
+from localci.core.orchestrator import OrchestratorConfig, ParallelExecutionManager
+from localci.core.platform_support import (
+    resolve_platform_outcome,
+    skipped_platform_message,
+    unsupported_platform_message,
+)
+from localci.core.queue import PriorityJobQueue
+from localci.core.queue_builder import QueueBuilder
+from localci.core.results import ExecutionSummary
+from localci.core.workflow import Platform, WorkflowAnalyzer
+
+from .test_queue import FULL_WORKFLOW as SAMPLE_WORKFLOW
+from .test_queue import make_entry, make_job
+
+
+class TestResolvePlatformOutcome:
+    def test_linux_default_runs(self) -> None:
+        entry = make_entry("GCC 15", platform=Platform.LINUX)
+        assert resolve_platform_outcome(entry, PlatformConfig()) == PlatformOutcome.RUN
+
+    def test_windows_default_fails(self) -> None:
+        entry = make_entry("MSVC", platform=Platform.WINDOWS, compiler="msvc")
+        entry.runs_on = "windows-2022"
+        assert resolve_platform_outcome(entry, PlatformConfig()) == PlatformOutcome.FAIL
+
+    def test_macos_default_fails(self) -> None:
+        entry = make_entry("Apple-Clang", platform=Platform.MACOS, compiler="clang")
+        entry.runs_on = "macos-26"
+        assert resolve_platform_outcome(entry, PlatformConfig()) == PlatformOutcome.FAIL
+
+    def test_windows_opt_in_skip(self) -> None:
+        entry = make_entry("MSVC", platform=Platform.WINDOWS, compiler="msvc")
+        entry.runs_on = "windows-latest"
+        cfg = PlatformConfig(windows=True)
+        assert resolve_platform_outcome(entry, cfg) == PlatformOutcome.SKIP
+
+    def test_macos_opt_in_skip(self) -> None:
+        entry = make_entry("Apple-Clang", platform=Platform.MACOS, compiler="clang")
+        entry.runs_on = "macos-latest"
+        cfg = PlatformConfig(macos=True)
+        assert resolve_platform_outcome(entry, cfg) == PlatformOutcome.SKIP
+
+
+class TestUnsupportedPlatformMessages:
+    def test_failure_message_names_job_and_platform(self) -> None:
+        entry = make_entry("MSVC 14.42", platform=Platform.WINDOWS, compiler="msvc")
+        entry.runs_on = "windows-2022"
+        msg = unsupported_platform_message("build", entry)
+        assert "build" in msg
+        assert "MSVC 14.42" in msg
+        assert "windows" in msg
+        assert "windows-2022" in msg
+        assert "Linux jobs only" in msg
+        assert "platforms.windows: true" in msg
+        assert "--platform linux" in msg
+
+    def test_skip_message_names_job_and_platform(self) -> None:
+        entry = make_entry("Apple-Clang", platform=Platform.MACOS, compiler="clang")
+        entry.runs_on = "macos-26"
+        msg = skipped_platform_message("build", entry)
+        assert "build" in msg
+        assert "Apple-Clang" in msg
+        assert "macos" in msg
+        assert "Linux-only" in msg
+
+
+class TestQueueBuilderPlatformOutcomes:
+    def test_mixed_platform_workflow_default_config(self) -> None:
+        analyzer = WorkflowAnalyzer()
+        workflow = analyzer.analyze(SAMPLE_WORKFLOW)
+        builder = QueueBuilder(workflow)
+        queue = builder.build(platform_config=PlatformConfig())
+        jobs = list(queue.get_all_jobs())
+        assert len(jobs) == 14
+
+        windows_jobs = [j for j in jobs if j.matrix_entry.platform == Platform.WINDOWS]
+        macos_jobs = [j for j in jobs if j.matrix_entry.platform == Platform.MACOS]
+        linux_jobs = [j for j in jobs if j.matrix_entry.platform == Platform.LINUX]
+
+        assert len(windows_jobs) == 3
+        assert len(macos_jobs) == 1
+        assert len(linux_jobs) == 10
+        assert all(j.platform_outcome == PlatformOutcome.FAIL for j in windows_jobs)
+        assert all(j.platform_outcome == PlatformOutcome.FAIL for j in macos_jobs)
+        assert all(j.platform_outcome == PlatformOutcome.RUN for j in linux_jobs)
+
+    def test_mixed_platform_opt_in_skip(self) -> None:
+        analyzer = WorkflowAnalyzer()
+        workflow = analyzer.analyze(SAMPLE_WORKFLOW)
+        builder = QueueBuilder(workflow)
+        queue = builder.build(
+            platform_config=PlatformConfig(windows=True, macos=True),
+        )
+        jobs = list(queue.get_all_jobs())
+        non_linux = [
+            j
+            for j in jobs
+            if j.matrix_entry.platform in (Platform.WINDOWS, Platform.MACOS)
+        ]
+        assert len(non_linux) == 4
+        assert all(j.platform_outcome == PlatformOutcome.SKIP for j in non_linux)
+
+
+class TestOrchestratorUnsupportedPlatform:
+    @patch("localci.core.orchestrator.ResourceMonitor")
+    @patch("localci.core.orchestrator.DockerManager")
+    @patch("localci.core.orchestrator.JobExecutor")
+    def test_windows_job_fails_without_invoking_act(
+        self, MockExecutor, MockDocker, MockMonitor, tmp_path: Path
+    ) -> None:
+        mock_executor = MockExecutor.return_value
+        mock_docker = MockDocker.return_value
+        mock_docker.cleanup_act_containers.return_value = 0
+        mock_monitor = MockMonitor.return_value
+        mock_monitor.check_thresholds.return_value = (True, [])
+        mock_monitor.snapshot.return_value = MagicMock(summary=lambda: "OK")
+
+        entry = make_entry("MSVC 14.42", platform=Platform.WINDOWS, compiler="msvc")
+        entry.runs_on = "windows-2022"
+        job = make_job("MSVC 14.42", compiler="msvc")
+        job.matrix_entry = entry
+        job.platform_outcome = PlatformOutcome.FAIL
+
+        queue = PriorityJobQueue()
+        queue.enqueue(job)
+
+        orchestrator = ParallelExecutionManager(
+            queue=queue,
+            workflow_file=Path("ci.yml"),
+            config=OrchestratorConfig(max_parallel=1),
+            logs_dir=tmp_path / "logs",
+        )
+        run = orchestrator.execute()
+
+        assert run.total == 1
+        assert run.failed == 1
+        assert run.all_passed is False
+        result = next(iter(run.results.values()))
+        assert result.status == JobStatus.FAILED
+        assert "Linux jobs only" in (result.error_message or "")
+        assert "windows" in (result.error_message or "")
+        mock_executor.run.assert_not_called()
+
+    @patch("localci.core.orchestrator.ResourceMonitor")
+    @patch("localci.core.orchestrator.DockerManager")
+    @patch("localci.core.orchestrator.JobExecutor")
+    def test_mixed_platform_no_clean_pass_with_default_config(
+        self, MockExecutor, MockDocker, MockMonitor, tmp_path: Path
+    ) -> None:
+        mock_executor = MockExecutor.return_value
+        mock_executor.run.return_value = JobResult(
+            job_id="build",
+            matrix_index=0,
+            matrix_name="GCC 15",
+            status=JobStatus.PASSED,
+            duration_seconds=1.0,
+        )
+        mock_docker = MockDocker.return_value
+        mock_docker.image_exists.return_value = True
+        mock_docker.cleanup_act_containers.return_value = 0
+        mock_monitor = MockMonitor.return_value
+        mock_monitor.check_thresholds.return_value = (True, [])
+        mock_monitor.snapshot.return_value = MagicMock(summary=lambda: "OK")
+
+        analyzer = WorkflowAnalyzer()
+        workflow = analyzer.analyze(SAMPLE_WORKFLOW)
+        queue = QueueBuilder(workflow).build(
+            platform_filter=Platform.LINUX,
+            platform_config=PlatformConfig(),
+        )
+        # Include one failing windows job alongside linux-only filter bypass test:
+        # build full mixed queue like a default run (no platform filter).
+        queue = QueueBuilder(workflow).build(platform_config=PlatformConfig())
+        linux_job = next(
+            j for j in queue.get_all_jobs() if j.platform_outcome == PlatformOutcome.RUN
+        )
+        windows_job = next(
+            j
+            for j in queue.get_all_jobs()
+            if j.platform_outcome == PlatformOutcome.FAIL
+        )
+
+        mixed_queue = PriorityJobQueue()
+        mixed_queue.enqueue(linux_job)
+        mixed_queue.enqueue(windows_job)
+
+        orchestrator = ParallelExecutionManager(
+            queue=mixed_queue,
+            workflow_file=SAMPLE_WORKFLOW,
+            config=OrchestratorConfig(max_parallel=2),
+            logs_dir=tmp_path / "logs",
+        )
+        run = orchestrator.execute()
+
+        assert run.failed == 1
+        assert run.passed == 1
+        assert run.all_passed is False
+        mock_executor.run.assert_called_once()
+
+    @patch("localci.core.orchestrator.ResourceMonitor")
+    @patch("localci.core.orchestrator.DockerManager")
+    @patch("localci.core.orchestrator.JobExecutor")
+    def test_opt_in_skip_allows_clean_pass(
+        self, MockExecutor, MockDocker, MockMonitor, tmp_path: Path
+    ) -> None:
+        mock_executor = MockExecutor.return_value
+        mock_executor.run.return_value = JobResult(
+            job_id="build",
+            matrix_index=0,
+            matrix_name="GCC 15",
+            status=JobStatus.PASSED,
+            duration_seconds=1.0,
+        )
+        mock_docker = MockDocker.return_value
+        mock_docker.image_exists.return_value = True
+        mock_docker.cleanup_act_containers.return_value = 0
+        mock_monitor = MockMonitor.return_value
+        mock_monitor.check_thresholds.return_value = (True, [])
+        mock_monitor.snapshot.return_value = MagicMock(summary=lambda: "OK")
+
+        analyzer = WorkflowAnalyzer()
+        workflow = analyzer.analyze(SAMPLE_WORKFLOW)
+        queue = QueueBuilder(workflow).build(
+            platform_config=PlatformConfig(windows=True, macos=True),
+        )
+        linux_job = next(
+            j for j in queue.get_all_jobs() if j.platform_outcome == PlatformOutcome.RUN
+        )
+        windows_job = next(
+            j
+            for j in queue.get_all_jobs()
+            if j.matrix_entry.platform == Platform.WINDOWS
+        )
+
+        mixed_queue = PriorityJobQueue()
+        mixed_queue.enqueue(linux_job)
+        mixed_queue.enqueue(windows_job)
+
+        orchestrator = ParallelExecutionManager(
+            queue=mixed_queue,
+            workflow_file=SAMPLE_WORKFLOW,
+            config=OrchestratorConfig(max_parallel=2),
+            logs_dir=tmp_path / "logs",
+        )
+        run = orchestrator.execute()
+
+        assert run.failed == 0
+        assert run.passed == 1
+        assert run.all_passed is True
+        skipped = [r for r in run.results.values() if r.status == JobStatus.SKIPPED]
+        assert len(skipped) == 1
+        mock_executor.run.assert_called_once()
+
+
+class TestExecutionSummarySkipped:
+    def test_skipped_jobs_allow_all_passed(self) -> None:
+        from datetime import datetime
+
+        summary = ExecutionSummary(
+            execution_id="test",
+            started_at=datetime.now(),
+            results=[
+                JobResult(
+                    job_id="build",
+                    matrix_index=0,
+                    matrix_name="GCC 15",
+                    status=JobStatus.PASSED,
+                ),
+                JobResult(
+                    job_id="build",
+                    matrix_index=1,
+                    matrix_name="MSVC",
+                    status=JobStatus.SKIPPED,
+                ),
+            ],
+        )
+        assert summary.all_passed is True
+
+    def test_failed_unsupported_blocks_all_passed(self) -> None:
+        from datetime import datetime
+
+        summary = ExecutionSummary(
+            execution_id="test",
+            started_at=datetime.now(),
+            results=[
+                JobResult(
+                    job_id="build",
+                    matrix_index=0,
+                    matrix_name="GCC 15",
+                    status=JobStatus.PASSED,
+                ),
+                JobResult(
+                    job_id="build",
+                    matrix_index=1,
+                    matrix_name="MSVC",
+                    status=JobStatus.FAILED,
+                    error_message="Linux jobs only",
+                ),
+            ],
+        )
+        assert summary.all_passed is False

--- a/cli/tests/test_progress.py
+++ b/cli/tests/test_progress.py
@@ -242,6 +242,29 @@ class TestProgressTracker:
         assert tracker._jobs[job.queue_key].status == QueuedJobStatus.PASSED
         assert tracker._jobs[job.queue_key].duration_seconds == 30.0
 
+    def test_track_skipped_job_not_shown_as_passed(self, tracker):
+        """A SKIPPED result on JOB_COMPLETED must not render as PASSED."""
+        job = make_job("MSVC", priority=1)
+
+        tracker.on_event(JobEvent(event_type=JobEventType.JOB_QUEUED, job=job))
+
+        result = JobResult(
+            job_id="build",
+            matrix_index=0,
+            matrix_name="MSVC",
+            status=JobStatus.SKIPPED,
+            error_message="platform not supported",
+        )
+        tracker.on_event(
+            JobEvent(
+                event_type=JobEventType.JOB_COMPLETED,
+                job=job,
+                data={"result": result},
+            )
+        )
+        assert tracker._jobs[job.queue_key].status == QueuedJobStatus.SKIPPED
+        assert tracker._jobs[job.queue_key].error_message == "platform not supported"
+
     def test_track_failure(self, tracker):
         job = make_job("Fail", priority=1)
 

--- a/cli/tests/test_progress.py
+++ b/cli/tests/test_progress.py
@@ -369,6 +369,44 @@ class TestProgressTracker:
         assert len(status["running_jobs"]) == 1
         assert status["failed_jobs"][0]["error_message"] == "error"
 
+    def test_get_status_dict_skipped_distinct_from_cancelled(self, tracker):
+        """Skipped jobs are reported separately from cancelled, with reasons."""
+        skipped_job = make_job("MSVC", priority=1, index=0)
+        tracker.on_event(JobEvent(event_type=JobEventType.JOB_QUEUED, job=skipped_job))
+        tracker.on_event(
+            JobEvent(
+                event_type=JobEventType.JOB_COMPLETED,
+                job=skipped_job,
+                data={
+                    "result": JobResult(
+                        job_id="build",
+                        matrix_index=0,
+                        matrix_name="MSVC",
+                        status=JobStatus.SKIPPED,
+                        error_message="platform not supported",
+                    )
+                },
+            )
+        )
+
+        cancelled_job = make_job("GCC", priority=1, index=1)
+        tracker.on_event(
+            JobEvent(event_type=JobEventType.JOB_QUEUED, job=cancelled_job)
+        )
+        tracker.on_event(
+            JobEvent(event_type=JobEventType.JOB_CANCELLED, job=cancelled_job)
+        )
+
+        status = tracker.get_status_dict()
+
+        assert status["skipped_count"] == 1
+        assert status["cancelled_count"] == 1
+        assert len(status["skipped_jobs"]) == 1
+        assert status["skipped_jobs"][0]["name"] == "MSVC"
+        assert status["skipped_jobs"][0]["status"] == QueuedJobStatus.SKIPPED.value
+        assert status["skipped_jobs"][0]["error_message"] == "platform not supported"
+        assert status["completed_count"] == 2
+
     def test_priority_levels(self, tracker):
         for i, (name, priority) in enumerate(
             [

--- a/cli/tests/test_run_flow.py
+++ b/cli/tests/test_run_flow.py
@@ -13,7 +13,7 @@ from localci.cli.run.container import build_run_container
 from localci.cli.run.params import RunOptions
 from localci.cli.run.run_flow import _resolve_matrix_filters, execute_run
 from localci.core.config import LocalCIConfig, MatrixConfig, MatrixFilter, PatchesConfig
-from localci.core.executor import ActNotFoundError
+from localci.core.executor import ActNotFoundError, JobResult, JobStatus
 from localci.core.workflow import (
     BuildSystem,
     BuildVariant,
@@ -52,6 +52,17 @@ def _dry_run_options(**overrides: object) -> RunOptions:
     )
     base.update(overrides)
     return RunOptions(**base)  # type: ignore[arg-type]
+
+
+def _passed_mock_run_results() -> dict[str, JobResult]:
+    return {
+        "build:0": JobResult(
+            job_id="build",
+            matrix_index=0,
+            matrix_name="GCC 15",
+            status=JobStatus.PASSED,
+        )
+    }
 
 
 @pytest.fixture
@@ -203,7 +214,7 @@ class TestExecuteRunDryRun:
         mock_run.execution_id = "test"
         mock_run.started_at = now
         mock_run.finished_at = now
-        mock_run.results = {}
+        mock_run.results = _passed_mock_run_results()
         mock_manager.execute.return_value = mock_run
         deps.parallel_manager_factory = lambda **_kwargs: mock_manager
 
@@ -264,7 +275,7 @@ class TestExecuteRunDryRun:
         mock_run.execution_id = "test"
         mock_run.started_at = now
         mock_run.finished_at = now
-        mock_run.results = {}
+        mock_run.results = _passed_mock_run_results()
         mock_manager = MagicMock()
         mock_manager.execute.return_value = mock_run
         deps.progress_tracker_factory = lambda **_kwargs: MagicMock()


### PR DESCRIPTION
## Summary

- Wire `platforms.windows` / `platforms.macos` into queue building and orchestration so Windows/macOS matrix entries no longer reach act with `image_tag=None` (opaque failure or misleading pass).
- Default config (`platforms.windows: false`, `platforms.macos: false`): unsupported jobs **fail** with a message naming the job, platform, and `runs-on`, stating Linux-only support.
- Opt-in skip remains: set `platforms.windows: true` or `platforms.macos: true` to **skip** those jobs without failing the overall run; `--platform linux` still limits execution to Linux entries.

## Test plan

- [x] `cd cli && pytest -q` — 622 passed
- [x] `pre-commit run -a` — ruff, ruff format, mypy all pass
- [x] Mixed-platform workflow (`sample_workflow.yml`): default config marks Windows/macOS jobs as fail, Linux as run
- [x] Orchestrator: Windows job fails without invoking act; mixed Linux+Windows run does not achieve `all_passed` under default config
- [x] Opt-in skip (`platforms.windows: true`): Windows job skipped, Linux job passes, `all_passed` is true

Closes #79

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added platform-aware handling for non-Linux matrix jobs with clear Linux-only guidance.
  - Windows/macOS jobs now either fail by default with an unsupported-platform message or skip cleanly when explicitly enabled.
  - Dry-run execution plans now show per-job outcomes (run/fail/skip).
- **Bug Fixes**
  - Empty executions now complete as non-passing (no longer “all passed”).
  - Skipped jobs are correctly reflected in overall verdicts and progress.
- **Documentation**
  - Updated guides, templates, and changelog to match the new fail-vs-skip behavior.
- **Tests**
  - Added/updated coverage for outcomes, messaging, orchestration, and summary semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->